### PR TITLE
Upgrade Azure SDK 1.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,9 @@
 
         <jenkins.version>2.60.1</jenkins.version>
         <java.level>8</java.level>
-        <azuresdk.version>1.3.0</azuresdk.version>
-        <azure-commons.version>0.2.3</azure-commons.version>
+        <azuresdk.version>1.15.1</azuresdk.version>
+        <azure-commons.version>0.2.7</azure-commons.version>
+	<jackson.version>2.9.4</jackson.version>
     </properties>
 
     <repositories>
@@ -124,12 +125,46 @@
                     <groupId>com.microsoft.azure</groupId>
                     <artifactId>azure-client-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-client-runtime</artifactId>
-            <version>1.5.4</version>
+            <version>1.6.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -156,13 +191,34 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.4</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-annotations</artifactId>
-            <version>1.3.0</version>
+            <version>1.7.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+	
     </dependencies>
 
     <build>

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureCachePool.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureCachePool.java
@@ -3,6 +3,7 @@ package com.microsoft.jenkins.azuread;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.graphrbac.implementation.UserGetMemberGroupsParametersInner;
 
 import java.util.Collection;
 import java.util.List;
@@ -17,6 +18,8 @@ public final class AzureCachePool {
     private static Cache<String, Collection<String>> belongingGroupsByOid =
             CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build();
     private final Azure.Authenticated azure;
+    private final UserGetMemberGroupsParametersInner allGroupMembers =
+        new UserGetMemberGroupsParametersInner().withSecurityEnabledOnly(false);
 
     private AzureCachePool(Azure.Authenticated azure) {
         this.azure = azure;
@@ -31,7 +34,7 @@ public final class AzureCachePool {
             Collection<String> result = belongingGroupsByOid.get(oid, new Callable<Collection<String>>() {
                 @Override
                 public Collection<String> call() throws Exception {
-                    List<String> groups = azure.activeDirectoryUsers().inner().getMemberGroups(oid, false);
+                    List<String> groups = azure.activeDirectoryUsers().inner().getMemberGroups(oid, allGroupMembers);
                     return groups;
                 }
             });


### PR DESCRIPTION
This pull request updates the Azure AD plugin to match the latest Azure Commons plugin version.

This requires updating Azure SDK to 1.15.1 and updating the `getMemberGroups` call to match the new API.

Without this update, we can't login on our Jenkins with plugin Azure Commons 0.2.7