### PR TITLE
Use UPN as authentication principal

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAuthenticationToken.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAuthenticationToken.java
@@ -40,7 +40,7 @@ public class AzureAuthenticationToken implements Authentication {
 
     @Override
     public Object getPrincipal() {
-        return azureAdUser.getObjectID();
+        return azureAdUser.getUniqueName();
     }
 
     @Override


### PR DESCRIPTION
Some user reports that with the new version plugin using UPN as Jenkins user id. They cannot call Jenkins REST API with UPN in some Jenkins version(Jenkins Enterprise). Command like `curl -k -u 'UPN:token' 'http://JENKINS_URL/user/UPN/configure'` will fail with no authentication.