### PR TITLE
Fix inconsistent users issue

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 
 public final class AzureAdUser implements UserDetails {
 
-    private String userName;
+    private String name;
 
     private String givenName;
 
@@ -43,7 +43,7 @@ public final class AzureAdUser implements UserDetails {
         }
 
         AzureAdUser user = new AzureAdUser();
-        user.userName = (String) claims.getClaimValue("name");
+        user.name = (String) claims.getClaimValue("name");
         user.givenName = (String) claims.getClaimValue("given_name");
         user.familyName = (String) claims.getClaimValue("family_name");
         user.uniqueName = (String) claims.getClaimValue("unique_name");
@@ -51,7 +51,7 @@ public final class AzureAdUser implements UserDetails {
         user.objectID = (String) claims.getClaimValue("oid");
         user.email = (String) claims.getClaimValue("email");
 
-        if (user.objectID == null || user.userName == null) {
+        if (user.objectID == null || user.name == null) {
             throw new BadCredentialsException("Invalid id token: " + claims.toJson());
         }
 
@@ -86,7 +86,7 @@ public final class AzureAdUser implements UserDetails {
 
         AzureAdUser that = (AzureAdUser) o;
 
-        if (userName != null ? !userName.equals(that.userName) : that.userName != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (givenName != null ? !givenName.equals(that.givenName) : that.givenName != null) return false;
         if (familyName != null ? !familyName.equals(that.familyName) : that.familyName != null) return false;
         if (uniqueName != null ? !uniqueName.equals(that.uniqueName) : that.uniqueName != null) return false;
@@ -97,7 +97,7 @@ public final class AzureAdUser implements UserDetails {
     @SuppressWarnings({"checkstyle:magicnumber"})
     @Override
     public int hashCode() {
-        int result = userName != null ? userName.hashCode() : 0;
+        int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (givenName != null ? givenName.hashCode() : 0);
         result = 31 * result + (familyName != null ? familyName.hashCode() : 0);
         result = 31 * result + (uniqueName != null ? uniqueName.hashCode() : 0);
@@ -118,7 +118,7 @@ public final class AzureAdUser implements UserDetails {
 
     @Override
     public String getUsername() {
-        return this.userName;
+        return getUniqueName();
     }
 
     @Override
@@ -151,6 +151,10 @@ public final class AzureAdUser implements UserDetails {
 
     public String getUniqueName() {
         return uniqueName;
+    }
+
+    public String getName() {
+        return this.name;
     }
 
     public String getFamilyName() {

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -208,7 +208,7 @@ public class AzureSecurityRealm extends SecurityRealm {
             if (u != null) {
                 String description = generateDescription(auth);
                 u.setDescription(description);
-                u.setFullName(auth.getAzureAdUser().getUsername());
+                u.setFullName(auth.getAzureAdUser().getName());
             }
             SecurityListener.fireAuthenticated(userDetails);
             AzureAdPlugin.sendLoginEvent(


### PR DESCRIPTION
Issue #34 

The [security advisory](https://jenkins.io/security/advisory/2019-01-16/) helps to expose an existing bug here.

Summary problem here is that when validate seed for current user, this plugin refers to different user ids in session and authentication.

The new seed security listener uses UserDetails#getUsername() to fetch a user which is implemented by [AzureAdUser#getUsername()](https://github.com/jenkinsci/azure-ad-plugin/blob/f8ef95f12ab579e43b232d4829c946847ddcf195/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java#L119-L122) returning the user name of a azure ad user.

In the HttpSessionContextIntegrationFilter2#hasInvalidSessionSeed() method, it gets a user by Authentication#getName() which is implemented in [AzureAuthenticationToken#getName()](https://github.com/jenkinsci/azure-ad-plugin/blob/f8ef95f12ab579e43b232d4829c946847ddcf195/src/main/java/com/microsoft/jenkins/azuread/AzureAuthenticationToken.java#L57-L59) returning the unique name of the azure ad user.

UserDetails#getUsername() returns the username to authenticate the user, so it should also be unique. I also refactored the former username variable to name to make consistent with previous version.
