### PR TITLE
Revert "Only expose UPN instead of Object ID"

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAuthenticationToken.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAuthenticationToken.java
@@ -40,7 +40,7 @@ public class AzureAuthenticationToken implements Authentication {
 
     @Override
     public Object getPrincipal() {
-        return this.getName();
+        return azureAdUser.getObjectID();
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 8c63c2a76c5684b2bae88cf8fb5aed37b6275e90.

Revert this commit in PR #26. This will be a break change for the current users' configuration. Will track it in the issue #28 to entirely enable this feature and automatically change the configuration for existing users. Not release it in this urgent release.