### PR TITLE
Mark compatible version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <jenkins.version>2.138.3</jenkins.version>
         <java.level>8</java.level>
         <azuresdk.version>1.15.1</azuresdk.version>
-        <azure-commons.version>1.0.2</azure-commons.version>
+        <azure-commons.version>1.0.3</azure-commons.version>
         <jackson.version>2.9.8</jackson.version>
         <workflow-cps.version>2.30</workflow-cps.version>
         <configuration-as-code.version>1.16</configuration-as-code.version>
@@ -242,6 +242,7 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
                     <minimumJavaVersion>1.8</minimumJavaVersion>
+                    <compatibleSinceVersion>1.0.0</compatibleSinceVersion>
                     <maskClasses>
                         com.microsoft.jenkins.azurecommons.core.
                         com.fasterxml.jackson.


### PR DESCRIPTION
Add mark for compatible version since the upgrade of Microsoft identity platform from v1.0 to v2.0. Users need to do some changes. Details have been in the README.

- Force users use https
- some used manifests have been optional