### PR TITLE
udpate jackson from 2.9.8 to 2.9.9 CVE-2019-12086

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-annotations</artifactId>
-                <version>1.7.0</version>
+                <version>1.8.0</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
@@ -211,6 +211,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.42</version>
+        <version>3.43</version>
     </parent>
 
     <artifactId>azure-ad</artifactId>
@@ -47,7 +47,7 @@
 
         <jenkins.version>2.138.3</jenkins.version>
         <java.level>8</java.level>
-        <azuresdk.version>1.15.1</azuresdk.version>
+        <azuresdk.version>1.22.0</azuresdk.version>
         <azure-commons.version>1.0.3</azure-commons.version>
         <jackson.version>2.9.9</jackson.version>
         <workflow-cps.version>2.30</workflow-cps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <java.level>8</java.level>
         <azuresdk.version>1.15.1</azuresdk.version>
         <azure-commons.version>1.0.3</azure-commons.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <workflow-cps.version>2.30</workflow-cps.version>
         <configuration-as-code.version>1.16</configuration-as-code.version>
     </properties>


### PR DESCRIPTION
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9

https://nvd.nist.gov/vuln/detail/CVE-2019-12086