### PR TITLE
support group based authorization without 'Read directory data' permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,29 @@ A Jenkins Plugin that supports authentication & authorization via Azure Active D
 
 1. To configure Azure Active Directory Matrix-based security, you have to add your `user/group` value with pattern `userName|groupName (principalName)`. The pattern `userName|groupName (objectId)` still works to make compatible with previous versions.
 
-Below two steps are optional since version 1.0.0. Without these steps:
-- You are not able to have autocompletion when adding user/group in Azure Active Directory Matrix.
-- You do not have the same privileges as the groups you belonged to.
+### Group Support
+
+For group support you have two options:
+
+1. Give Jenkins the right to `Read directory data` in `Azure Active Directory`(Azure admin right required), which in addition to group support also allows to use autocompletion when adding user/group in Azure Active Directory Matrix
+1. Let Azure Active Directory provide the `groups` of an user as part of the id token.
+
+**Option 1:**
+
+Give Jenkins permission to `Read directory data` in `Azure Active Directory` to get autocompletion support in Azure Active Directory Matrix
 
 1. In Application setting page, click `Required Permissions` and select `Windows Azure Active Directory`, then select `Read directory data` permissions in Application permissions section
 
 1. Click `Grant Permissions`. If you are not an admin in your tenant, please contact admin to grant the permissions which declared as `require admin` in `Enable Access` page. Wait for the permissions taking effects.
 
+**Option 2:**
+
+Let Azure Active Directory provide the `groups` of an user as part of the id token.
+
+1. In Azure Application settings, click `Authentication` and mark the `ID tokens` checkbox under `Advanced Settings -> Implicit grant`. Save settings.
+1. In Azure Application settings, click `Manifest` and modify the `"groupMembershipClaims": "None"` value to `"groupMembershipClaims": "SecurityGroup"`. Save manifest.
+1. To setup group based authentication in Jenkins, you should search and take note of the groups `Object Id` and `Name` you want to use for Jenkins authorization.
+1. In Jenkins configure `Azure Active Directory Matrix`-based security and add the noted down groups one-by-one in the following notation: `groupName (objectId)`
 
 ## Setup In Jenkins
 

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
@@ -11,6 +11,7 @@ import org.acegisecurity.BadCredentialsException;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.userdetails.UserDetails;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
@@ -126,7 +127,11 @@ public final class AzureAdUser implements UserDetails {
         if (familyName != null ? !familyName.equals(that.familyName) : that.familyName != null) return false;
         if (uniqueName != null ? !uniqueName.equals(that.uniqueName) : that.uniqueName != null) return false;
         if (tenantID != null ? !tenantID.equals(that.tenantID) : that.tenantID != null) return false;
-        if (groupOIDs != null ? !groupOIDs.equals(that.groupOIDs) : that.groupOIDs != null) return false;
+        if (groupOIDs != null && that.groupOIDs != null) {
+                if (!CollectionUtils.isEqualCollection(groupOIDs, that.groupOIDs)) return false;
+        } else if (groupOIDs != null || that.groupOIDs != null) {
+            return false;
+        }
         return objectID.equals(that.objectID);
     }
 

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -45,6 +45,7 @@ import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.jose4j.jwt.consumer.JwtConsumer;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -185,7 +186,7 @@ public class AzureSecurityRealm extends SecurityRealm {
                 "response_mode", "form_post")));
     }
 
-    public HttpResponse doFinishLogin(StaplerRequest request) throws InvalidJwtException {
+    public HttpResponse doFinishLogin(StaplerRequest request) throws InvalidJwtException, MalformedClaimException {
         try {
             final Long beginTime = (Long) request.getSession().getAttribute(TIMESTAMP_ATTRIBUTE);
             final String expectedNonce = (String) request.getSession().getAttribute(NONCE_ATTRIBUTE);
@@ -233,7 +234,8 @@ public class AzureSecurityRealm extends SecurityRealm {
         }
     }
 
-    AzureAdUser validateAndParseIdToken(String expectedNonce, String idToken) throws InvalidJwtException {
+    AzureAdUser validateAndParseIdToken(String expectedNonce, String idToken)
+        throws InvalidJwtException, MalformedClaimException {
         JwtClaims claims = getJwtConsumer().processToClaims(idToken);
         final String responseNonce = (String) claims.getClaimValue("nonce");
         if (StringUtils.isAnyEmpty(expectedNonce, responseNonce) || !expectedNonce.equals(responseNonce)) {
@@ -395,7 +397,8 @@ public class AzureSecurityRealm extends SecurityRealm {
                     + "\nUnique Principal Name: " + user.getUniqueName()
                     + "\nEmail: " + user.getEmail()
                     + "\nObject ID: " + user.getObjectID()
-                    + "\nTenant ID: " + user.getTenantID() + "\n";
+                    + "\nTenant ID: " + user.getTenantID()
+                    + "\nGroups: " + user.getGroupOIDs() + "\n";
         }
         return "";
     }


### PR DESCRIPTION
Hi,

this pull-request introduces support for group based Azure AD authentication and authorization without needing 'Read directory data' permissions.
Instead, Azure Active directory is configured to send the user groups as part of the ID token. This setting doesn't need admin rights.

It was a quick test yesterday and worked surprisingly perfectly for me. But I wasn't able to verify, that the 'Read directory data' group support is still working fine.
I updated the README accordingly and hope it helps others to verify this change is working for them as well.