### PR TITLE
Use `sub` claim instead of `email` for user cache

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -229,7 +229,7 @@ public class AzureSecurityRealm extends SecurityRealm {
             }
             // validate the nonce to avoid CSRF
             final JwtClaims claims = validateIdToken(expectedNonce, idToken);
-            String key = (String) claims.getClaimValue("email");
+            String key = (String) claims.getClaimValue("sub");
 
 
             AzureAdUser userDetails = caches.get(key, () -> {


### PR DESCRIPTION
After the update to 1.1.1 we were locked out of our Jenkins instance that was using AAD to provide security (with this plugin). It turns out (or I missed something when reading the docs) that if you have pure-Azure AAD tenant (i.e. without Office 365/Exchange or any other service), [you don't have `email` claim and you can't configure it](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set) (search for `email` claim). This results in failed auth requests, because `LocalCache` can't be keyed with `null`s. The change was introduced in PR #61 and is [around here](https://github.com/jenkinsci/azure-ad-plugin/blob/dev/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java#L235).
To sum up, in our configuration, claim `email` does not exist for any user and therefore results in `NullPointerException` when trying to find user in the cache.

I propose to use `sub` claim from the [id token](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens) as cache key since it is always available and does not require additional configuration.