### PR TITLE
fix jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,12 +139,6 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
-            <artifactId>configuration-as-code-support</artifactId>
-            <version>${configuration-as-code.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <version>${configuration-as-code.version}</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -120,11 +120,6 @@
             <version>${azuresdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.7</version>
@@ -222,6 +217,11 @@
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>structs</artifactId>
                 <version>1.13</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <azure-commons.version>1.0.3</azure-commons.version>
         <jackson.version>2.10.0</jackson.version>
         <workflow-cps.version>2.30</workflow-cps.version>
-        <configuration-as-code.version>1.16</configuration-as-code.version>
+        <configuration-as-code.version>1.35</configuration-as-code.version>
     </properties>
 
     <repositories>
@@ -144,10 +144,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
             <version>${configuration-as-code.version}</version>
-            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>azure-ad</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>1.1.2</version>
 
     <name>Azure AD Plugin</name>
     <description>A Jenkins authentication &amp; authorization plugin for Azure Active Directory</description>
@@ -36,7 +36,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/azure-ad-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/azure-ad-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/azure-ad-plugin</url>
-        <tag>${scmTag}</tag>
+        <tag>azure-ad-1.1.2</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.55</version>
+        <version>3.56</version>
     </parent>
 
     <artifactId>azure-ad</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>azure-ad</artifactId>
-    <version>1.1.2</version>
+    <version>${revision}${changelist}</version>
 
     <name>Azure AD Plugin</name>
     <description>A Jenkins authentication &amp; authorization plugin for Azure Active Directory</description>
@@ -36,11 +36,11 @@
         <connection>scm:git:ssh://github.com/jenkinsci/azure-ad-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/azure-ad-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/azure-ad-plugin</url>
-        <tag>azure-ad-1.1.2</tag>
+        <tag>${scmTag}</tag>
     </scm>
 
     <properties>
-        <revision>1.1.2</revision>
+        <revision>1.1.3</revision>
         <changelist>-SNAPSHOT</changelist>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a tests classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
jenkinsci/bom#164

Note: We'll need a release for PCT please