### PR TITLE
Feature/callbackurl from request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>azure-ad</artifactId>
-    <version>1.1.2</version>
+    <version>${revision}${changelist}</version>
 
     <name>Azure AD Plugin</name>
     <description>A Jenkins authentication &amp; authorization plugin for Azure Active Directory</description>
@@ -36,11 +36,11 @@
         <connection>scm:git:ssh://github.com/jenkinsci/azure-ad-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/azure-ad-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/azure-ad-plugin</url>
-        <tag>azure-ad-1.1.2</tag>
+        <tag>${scmTag}</tag>
     </scm>
 
     <properties>
-        <revision>1.1.2</revision>
+        <revision>1.1.3</revision>
         <changelist>-SNAPSHOT</changelist>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -82,7 +82,6 @@ public class AzureSecurityRealm extends SecurityRealm {
     private static final String CONVERTER_NODE_CLIENT_SECRET = "clientsecret";
     private static final String CONVERTER_NODE_TENANT = "tenant";
     private static final String CONVERTER_NODE_CACHE_DURATION = "cacheduration";
-    private static final String CONVERTER_NODE_FROM_REQUEST = "fromrequest";
     private static final int CACHE_KEY_LOG_LENGTH = 8;
 
     private Cache<String, AzureAdUser> caches;

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -82,6 +82,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     private static final String CONVERTER_NODE_CLIENT_SECRET = "clientsecret";
     private static final String CONVERTER_NODE_TENANT = "tenant";
     private static final String CONVERTER_NODE_CACHE_DURATION = "cacheduration";
+    private static final String CONVERTER_NODE_FROM_REQUEST = "fromrequest";
     private static final int CACHE_KEY_LOG_LENGTH = 8;
 
     private Cache<String, AzureAdUser> caches;
@@ -166,8 +167,8 @@ public class AzureSecurityRealm extends SecurityRealm {
     }
 
     @DataBoundSetter
-    public void setFromRequest(boolean fromrequest) {
-        this.fromRequest = fromrequest;
+    public void setFromRequest(boolean fromRequest) {
+        this.fromRequest = fromRequest;
     }
 
     public JwtConsumer getJwtConsumer() {
@@ -367,6 +368,10 @@ public class AzureSecurityRealm extends SecurityRealm {
             writer.startNode(CONVERTER_NODE_CACHE_DURATION);
             writer.setValue(String.valueOf(realm.getCacheDuration()));
             writer.endNode();
+
+            writer.startNode(CONVERTER_NODE_FROM_REQUEST);
+            writer.setValue(String.valueOf(realm.isFromRequest()));
+            writer.endNode();
         }
 
         @Override
@@ -388,6 +393,9 @@ public class AzureSecurityRealm extends SecurityRealm {
                         break;
                     case CONVERTER_NODE_CACHE_DURATION:
                         realm.setCacheDuration(Integer.parseInt(value));
+                        break;
+                    case CONVERTER_NODE_FROM_REQUEST:
+                        realm.setFromRequest(Boolean.parseBoolean(value));
                         break;
                     default:
                         break;

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -196,8 +196,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     }
 
     @DataBoundConstructor
-    public AzureSecurityRealm(String tenant, String clientId, String clientSecret, int cacheDuration)
-            throws ExecutionException, IOException, InterruptedException {
+    public AzureSecurityRealm(String tenant, String clientId, String clientSecret, int cacheDuration) {
         super();
         this.clientId = Secret.fromString(clientId);
         this.clientSecret = Secret.fromString(clientSecret);

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
@@ -18,8 +18,13 @@
             <f:textbox />
         </f:entry>
 
+
         <f:entry title="Cache Duration" field="cacheDuration" help="/plugin/azure-ad/help/help-cache-duration.html">
             <f:textbox />
+        </f:entry>
+
+        <f:entry title="Callback URL from request" field="fromRequest" help="/plugin/azure-ad/help/help-from-request.html">
+            <f:checkbox />
         </f:entry>
 
         <f:validateButton title="Verify Application" method="verifyConfiguration" progress="Verifying..." with="clientId,clientSecret,tenant" ></f:validateButton>

--- a/src/main/webapp/help/help-from-request.html
+++ b/src/main/webapp/help/help-from-request.html
@@ -1,0 +1,3 @@
+<div>
+    If checked, the callback URL - aka redirect URI - will be determined based on the request and not from Jenkins URL
+</div>

--- a/src/test/java/com/microsoft/jenkins/azuread/AzureAdConfigurationSaveTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/AzureAdConfigurationSaveTest.java
@@ -1,0 +1,54 @@
+package com.microsoft.jenkins.azuread;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class AzureAdConfigurationSaveTest {
+
+    public static final String TENANT = "tenant";
+    public static final String CLIENT_ID = "clientId";
+    public static final String CLIENT_SECRET = "thisIsSpecialSecret";
+    public static final int CACHE_DURATION = 15;
+    @Rule
+    public final RestartableJenkinsRule r = new RestartableJenkinsRule();
+
+    @Test
+    public void FromRequestSaveTest() throws Exception {
+
+        r.then(r->{
+            AzureSecurityRealm realm = new AzureSecurityRealm(
+                    TENANT,
+                    CLIENT_ID,
+                    CLIENT_SECRET,
+                    CACHE_DURATION);
+            realm.setFromRequest(true);
+            r.jenkins.setSecurityRealm(realm);
+
+            AzureSecurityRealm result = (AzureSecurityRealm) r.jenkins.getSecurityRealm();
+            assertThat(result, is(notNullValue()));
+            assertThat(result.isFromRequest(), is(true));
+            assertThat(result.getTenant(), is(TENANT));
+            assertThat(result.getClientId(), is(CLIENT_ID));
+            assertThat(result.getClientSecret(), is(CLIENT_SECRET));
+            assertThat(result.getCacheDuration(), is(CACHE_DURATION));
+
+        });
+        r.then(r -> {
+            AzureSecurityRealm result = (AzureSecurityRealm) r.jenkins.getSecurityRealm();
+            assertThat(result, is(notNullValue()));
+            assertThat(result.isFromRequest(), is(true));
+            assertThat(result.getTenant(), is(TENANT));
+            assertThat(result.getClientId(), is(CLIENT_ID));
+            assertThat(result.getClientSecret(), is(CLIENT_SECRET));
+            assertThat(result.getCacheDuration(), is(CACHE_DURATION));
+
+        });
+
+    }
+
+}

--- a/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
@@ -28,8 +28,7 @@ public class AzureSecurityRealmTest {
         BinaryStreamReader reader = null;
         try {
 
-            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", "secret", 0, true);
-
+            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", "secret", 0);
             AzureSecurityRealm.ConverterImpl converter = new AzureSecurityRealm.ConverterImpl();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             writer = new BinaryStreamWriter(outputStream);
@@ -44,7 +43,6 @@ public class AzureSecurityRealmTest {
             Assert.assertEquals(securityRealm.getClientId(), result.getClientId());
             Assert.assertEquals(securityRealm.getClientSecret(), result.getClientSecret());
             Assert.assertEquals(securityRealm.getCacheDuration(), result.getCacheDuration());
-            Assert.assertEquals(securityRealm.isFromRequest(), result.isFromRequest());
         } finally {
             if (writer != null) {
                 writer.close();
@@ -60,7 +58,7 @@ public class AzureSecurityRealmTest {
         BinaryStreamWriter writer = null;
         try {
             String secretString = "thisIsSpecialSecret";
-            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", secretString, 0, true);
+            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", secretString, 0);
 
             AzureSecurityRealm.ConverterImpl converter = new AzureSecurityRealm.ConverterImpl();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
@@ -27,7 +27,7 @@ public class AzureSecurityRealmTest {
         BinaryStreamWriter writer = null;
         BinaryStreamReader reader = null;
         try {
-            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", "secret", 0);
+            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", "secret", 0, true);
             AzureSecurityRealm.ConverterImpl converter = new AzureSecurityRealm.ConverterImpl();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             writer = new BinaryStreamWriter(outputStream);
@@ -42,6 +42,7 @@ public class AzureSecurityRealmTest {
             Assert.assertEquals(securityRealm.getClientId(), result.getClientId());
             Assert.assertEquals(securityRealm.getClientSecret(), result.getClientSecret());
             Assert.assertEquals(securityRealm.getCacheDuration(), result.getCacheDuration());
+            Assert.assertEquals(securityRealm.isFromRequest(), result.isFromRequest());
         } finally {
             if (writer != null) {
                 writer.close();
@@ -57,7 +58,8 @@ public class AzureSecurityRealmTest {
         BinaryStreamWriter writer = null;
         try {
             String secretString = "thisIsSpecialSecret";
-            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", secretString, 0);
+
+            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", secretString, 0, true);
             AzureSecurityRealm.ConverterImpl converter = new AzureSecurityRealm.ConverterImpl();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             writer = new BinaryStreamWriter(outputStream);

--- a/src/test/java/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest.java
@@ -48,6 +48,7 @@ public class ConfigAsCodeTest {
         assertEquals("clientSecret", azureSecurityRealm.getClientSecret());
         assertEquals("tenantId", azureSecurityRealm.getTenant());
         assertEquals(0, azureSecurityRealm.getCacheDuration());
+        assertTrue(azureSecurityRealm.isFromRequest());
 
         AuthorizationStrategy authorizationStrategy = j.jenkins.getAuthorizationStrategy();
         assertTrue("authorization strategy", authorizationStrategy instanceof AzureAdMatrixAuthorizationStrategy);
@@ -75,7 +76,7 @@ public class ConfigAsCodeTest {
         CNode realmNode = realmConfigurator.describe(securityRealm, context);
         assertNotNull(realmNode);
         Mapping realMapping = realmNode.asMapping();
-        assertEquals(4, realMapping.size());
+        assertEquals(5, realMapping.size());
 
         AzureSecurityRealm azureSecurityRealm = (AzureSecurityRealm) securityRealm;
         String encryptedClientSecret = azureSecurityRealm.getClientSecretSecret();

--- a/src/test/java/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest.java
@@ -76,7 +76,7 @@ public class ConfigAsCodeTest {
         CNode realmNode = realmConfigurator.describe(securityRealm, context);
         assertNotNull(realmNode);
         Mapping realMapping = realmNode.asMapping();
-        assertEquals(4, realMapping.size());
+        assertEquals(5, realMapping.size());
 
         AzureSecurityRealm azureSecurityRealm = (AzureSecurityRealm) securityRealm;
         String encryptedClientSecret = azureSecurityRealm.getClientSecretSecret();

--- a/src/test/java/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest.java
@@ -76,7 +76,7 @@ public class ConfigAsCodeTest {
         CNode realmNode = realmConfigurator.describe(securityRealm, context);
         assertNotNull(realmNode);
         Mapping realMapping = realmNode.asMapping();
-        assertEquals(5, realMapping.size());
+        assertEquals(4, realMapping.size());
 
         AzureSecurityRealm azureSecurityRealm = (AzureSecurityRealm) securityRealm;
         String encryptedClientSecret = azureSecurityRealm.getClientSecretSecret();

--- a/src/test/resources/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest/config.xml
+++ b/src/test/resources/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest/config.xml
@@ -30,6 +30,7 @@
         <clientsecret>password</clientsecret>
         <tenant>tenantId</tenant>
         <cacheduration>0</cacheduration>
+        <fromrequest>true</fromrequest>
     </securityRealm>
     <disableRememberMe>false</disableRememberMe>
     <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>

--- a/src/test/resources/com/microsoft/jenkins/azuread/integrations/casc/configuration-as-code.yml
+++ b/src/test/resources/com/microsoft/jenkins/azuread/integrations/casc/configuration-as-code.yml
@@ -38,3 +38,4 @@ jenkins:
       clientsecret: "clientSecret"
       tenant: "tenantId"
       cacheduration: 0
+      fromrequest: true


### PR DESCRIPTION
From time to time, Jenkins is not accessed by a unique URL.
It was not possible to use Azure AD authentication in this case as the callback URL was retrieved based on the unique URL of Jenkins store in the configuration.

This feature allows to build the callback URL based on the request.

I do not think this is a security issue, especially because Azure controls the redirect URI/callback URL.

In any case, I have added a checkbox to activate this behavior.