### PR TITLE
feature: remove unwanted username suffixes

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
@@ -55,7 +55,8 @@ public final class AzureAdUser implements UserDetails {
         authorities = new GrantedAuthority[]{SecurityRealm.AUTHENTICATED_AUTHORITY};
     }
 
-    public static AzureAdUser createFromJwt(JwtClaims claims) throws MalformedClaimException {
+    public static AzureAdUser createFromJwt(JwtClaims claims, String unwantedUsernameSuffixes)
+            throws MalformedClaimException {
         if (claims == null) {
             return null;
         }
@@ -68,6 +69,14 @@ public final class AzureAdUser implements UserDetails {
         if (StringUtils.isEmpty(user.uniqueName)) {
             user.uniqueName = (String) claims.getClaimValue("preferred_username");
         }
+        for (String suffix : unwantedUsernameSuffixes.split(",")) {
+            if (user.uniqueName.endsWith(suffix)) {
+                int idx = user.uniqueName.lastIndexOf(suffix);
+                user.uniqueName = user.uniqueName.substring(0, idx);
+                break;
+            }
+        }
+
         user.tenantID = (String) claims.getClaimValue("tid");
         user.objectID = (String) claims.getClaimValue("oid");
         user.email = (String) claims.getClaimValue("email");

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
@@ -71,7 +71,7 @@ public final class AzureAdUser implements UserDetails {
         }
         for (String suffix : unwantedUsernameSuffixes.split(",")) {
             if (user.uniqueName.endsWith(suffix)) {
-                int idx = user.uniqueName.lastIndexOf(suffix);
+                int idx = user.uniqueName.length() - suffix.length();
                 user.uniqueName = user.uniqueName.substring(0, idx);
                 break;
             }

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -415,9 +415,11 @@ public class AzureSecurityRealm extends SecurityRealm {
                         break;
                     case CONVERTER_NODE_UNWANTED_USERNAME_SUFFIXES:
                         realm.setUnwantedUsernameSuffixes(value);
+                        break;
                     default:
                         break;
                 }
+
                 reader.moveUp();
             }
             Cache<String, AzureAdUser> caches = CacheBuilder.newBuilder()

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
@@ -26,6 +26,10 @@
             <f:checkbox />
         </f:entry>
 
+        <f:entry title="Unwanted username suffixes" field="unwantedUsernameSuffixes" help="/plugin/azure-ad/help/help-username-suffixes-remove.html">
+            <f:textbox />
+        </f:entry>
+
         <f:validateButton title="Verify Application" method="verifyConfiguration" progress="Verifying..." with="clientId,clientSecret,tenant" ></f:validateButton>
     </f:block>
 </j:jelly>

--- a/src/main/webapp/help/help-username-suffixes-remove.html
+++ b/src/main/webapp/help/help-username-suffixes-remove.html
@@ -1,0 +1,4 @@
+<div>
+    A comma-separated list of username suffixes, which will be removed during user creation.<br>
+    This option can be useful if your Azure AD app returns e-mail instead of username in <code>upn</code> or <code>preferred_username</code>.
+</div>

--- a/src/test/java/com/microsoft/jenkins/azuread/AzureAdConfigurationSaveTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/AzureAdConfigurationSaveTest.java
@@ -14,6 +14,7 @@ public class AzureAdConfigurationSaveTest {
     public static final String CLIENT_ID = "clientId";
     public static final String CLIENT_SECRET = "thisIsSpecialSecret";
     public static final int CACHE_DURATION = 15;
+    public static final String UNWANTED_USERNAME_SUFFIXES = "suffix";
     @Rule
     public final RestartableJenkinsRule r = new RestartableJenkinsRule();
 
@@ -25,7 +26,8 @@ public class AzureAdConfigurationSaveTest {
                     TENANT,
                     CLIENT_ID,
                     CLIENT_SECRET,
-                    CACHE_DURATION);
+                    CACHE_DURATION,
+                    UNWANTED_USERNAME_SUFFIXES);
             realm.setFromRequest(true);
             r.jenkins.setSecurityRealm(realm);
 

--- a/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
@@ -43,6 +43,7 @@ public class AzureSecurityRealmTest {
             Assert.assertEquals(securityRealm.getClientId(), result.getClientId());
             Assert.assertEquals(securityRealm.getClientSecret().getPlainText(), result.getClientSecret().getPlainText());
             Assert.assertEquals(securityRealm.getCacheDuration(), result.getCacheDuration());
+            Assert.assertEquals(securityRealm.getUnwantedUsernameSuffixes(), result.getUnwantedUsernameSuffixes());
         } finally {
             if (writer != null) {
                 writer.close();

--- a/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
@@ -28,7 +28,7 @@ public class AzureSecurityRealmTest {
         BinaryStreamReader reader = null;
         try {
 
-            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", "secret", 0);
+            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", "secret", 0, "suffix");
             AzureSecurityRealm.ConverterImpl converter = new AzureSecurityRealm.ConverterImpl();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             writer = new BinaryStreamWriter(outputStream);
@@ -58,7 +58,7 @@ public class AzureSecurityRealmTest {
         BinaryStreamWriter writer = null;
         try {
             String secretString = "thisIsSpecialSecret";
-            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", secretString, 0);
+            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", secretString, 0, "suffix");
 
             AzureSecurityRealm.ConverterImpl converter = new AzureSecurityRealm.ConverterImpl();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/src/test/java/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest.java
@@ -76,7 +76,7 @@ public class ConfigAsCodeTest {
         CNode realmNode = realmConfigurator.describe(securityRealm, context);
         assertNotNull(realmNode);
         Mapping realMapping = realmNode.asMapping();
-        assertEquals(5, realMapping.size());
+        assertEquals(6, realMapping.size());
 
         AzureSecurityRealm azureSecurityRealm = (AzureSecurityRealm) securityRealm;
         String encryptedClientSecret = azureSecurityRealm.getClientSecretSecret();
@@ -90,6 +90,9 @@ public class ConfigAsCodeTest {
         CNode node = c.describe(authorizationStrategy, context);
         assertNotNull(node);
         Mapping mapping = node.asMapping();
+
+        String unwantedUsernameSuffixes = azureSecurityRealm.getUnwantedUsernameSuffixes();
+        assertEquals("suffix", unwantedUsernameSuffixes);
 
         List<CNode> permissions = mapping.get("permissions").asSequence();
         assertEquals("list size", 18, permissions.size());

--- a/src/test/resources/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest/config.xml
+++ b/src/test/resources/com/microsoft/jenkins/azuread/integrations/casc/ConfigAsCodeTest/config.xml
@@ -31,6 +31,7 @@
         <tenant>tenantId</tenant>
         <cacheduration>0</cacheduration>
         <fromrequest>true</fromrequest>
+        <unwantedusernamesuffixes>suffix</unwantedusernamesuffixes>
     </securityRealm>
     <disableRememberMe>false</disableRememberMe>
     <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>

--- a/src/test/resources/com/microsoft/jenkins/azuread/integrations/casc/configuration-as-code.yml
+++ b/src/test/resources/com/microsoft/jenkins/azuread/integrations/casc/configuration-as-code.yml
@@ -39,3 +39,4 @@ jenkins:
       tenant: "tenantId"
       cacheduration: 0
       fromrequest: true
+      unwantedusernamesuffixes: "suffix"


### PR DESCRIPTION
Add new field `unwantedUsernameSuffixes` in `Azure Realm`. 

This field is used to filter unwanted suffixes (primarily e-mails) in JWT token's claims, like `upn` and `preferred_username`.

Primary use-case:
* Users authenticate with `Azure AD`
* JWT token from `Azure AD` contains email in `upn` claim
* User's `Jenkins ID` is email now

=>

Broken compatibility with `Git Plugin` which matches username part in email (username@example.com) to `Jenkins ID`, and creates a new user, if username not found .
Such behavior leads to profile duplication and broken notifications (by default new users have no rights).

I don't think it's the right place to fix, but issues like [JENKINS-9016](https://issues.jenkins-ci.org/browse/JENKINS-9016) are almost 10 years old and I don't think it'll change anytime soon (or at all), yet we need fix now.

Another correct solution would be to update UPN value in Azure AD, but it's close to impossible in a big company.