### PR TITLE
Fix Security Realm AAD verify failed bug

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -197,10 +197,10 @@ public class AzureSecurityRealm extends SecurityRealm {
     }
 
     @DataBoundConstructor
-    public AzureSecurityRealm(String tenant, String clientId, String clientSecret, int cacheDuration) {
+    public AzureSecurityRealm(String tenant, String clientId, Secret clientSecret, int cacheDuration) {
         super();
         this.clientId = Secret.fromString(clientId);
-        this.clientSecret = Secret.fromString(clientSecret);
+        this.clientSecret = clientSecret;
         this.tenant = Secret.fromString(tenant);
         this.cacheDuration = cacheDuration;
         caches = CacheBuilder.newBuilder()
@@ -443,14 +443,14 @@ public class AzureSecurityRealm extends SecurityRealm {
         }
 
         public FormValidation doVerifyConfiguration(@QueryParameter final String clientId,
-                                                    @QueryParameter final String clientSecret,
+                                                    @QueryParameter final Secret clientSecret,
                                                     @QueryParameter final String tenant)
                 throws IOException, ExecutionException {
 
 
             AzureTokenCredentials credential = new ApplicationTokenCredentials(clientId,
                     tenant,
-                    clientSecret,
+                    clientSecret.getPlainText(),
                     AzureEnvironment.AZURE);
             try {
                 Azure.authenticate(credential).subscriptions().list();

--- a/src/test/java/com/microsoft/jenkins/azuread/AzureAdConfigurationSaveTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/AzureAdConfigurationSaveTest.java
@@ -1,5 +1,6 @@
 package com.microsoft.jenkins.azuread;
 
+import hudson.util.Secret;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
@@ -24,7 +25,7 @@ public class AzureAdConfigurationSaveTest {
             AzureSecurityRealm realm = new AzureSecurityRealm(
                     TENANT,
                     CLIENT_ID,
-                    CLIENT_SECRET,
+                    Secret.fromString(CLIENT_SECRET),
                     CACHE_DURATION);
             realm.setFromRequest(true);
             r.jenkins.setSecurityRealm(realm);

--- a/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/AzureSecurityRealmTest.java
@@ -2,6 +2,7 @@ package com.microsoft.jenkins.azuread;
 
 import com.thoughtworks.xstream.io.binary.BinaryStreamReader;
 import com.thoughtworks.xstream.io.binary.BinaryStreamWriter;
+import hudson.util.Secret;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,7 +29,7 @@ public class AzureSecurityRealmTest {
         BinaryStreamReader reader = null;
         try {
 
-            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", "secret", 0);
+            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", Secret.fromString("secret"), 0);
             AzureSecurityRealm.ConverterImpl converter = new AzureSecurityRealm.ConverterImpl();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             writer = new BinaryStreamWriter(outputStream);
@@ -58,7 +59,7 @@ public class AzureSecurityRealmTest {
         BinaryStreamWriter writer = null;
         try {
             String secretString = "thisIsSpecialSecret";
-            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", secretString, 0);
+            AzureSecurityRealm securityRealm = new AzureSecurityRealm("tenant", "clientId", Secret.fromString(secretString), 0);
 
             AzureSecurityRealm.ConverterImpl converter = new AzureSecurityRealm.ConverterImpl();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
AAD verify failed

### Reproduce step
1. Go to ```Jenkins -> Configure Global Security -> Security Realm```, add AAD configs,  apply&save.
2. Back to ```Jenkins -> Configure Global Security -> Security Realm``` and to verify action
![image](https://user-images.githubusercontent.com/57888764/81668898-ec052280-9477-11ea-9fa5-1dce0faf13d2.png)
### Fix 
Return real ```ClientSecret``` value, not encrypt value.