### PR TITLE
[JENKINS-64858] - Enabled support for Job DSL plugin

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixFolderProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixFolderProperty.java
@@ -1,22 +1,45 @@
 package com.microsoft.jenkins.azuread;
 
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty;
 import hudson.Extension;
 import hudson.model.AutoCompletionCandidates;
+import hudson.model.Item;
 import hudson.security.Permission;
+import hudson.security.PermissionScope;
+import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.matrixauth.AbstractAuthorizationPropertyConverter;
+import org.jenkinsci.plugins.matrixauth.AuthorizationPropertyDescriptor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.verb.GET;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.List;
 
 public class AzureAdAuthorizationMatrixFolderProperty extends AuthorizationMatrixProperty {
 
     private final transient ObjId2FullSidMap objId2FullSidMap = new ObjId2FullSidMap();
 
     protected AzureAdAuthorizationMatrixFolderProperty() {
+    }
+
+    @DataBoundConstructor
+    @Restricted(NoExternalUse.class)
+    public AzureAdAuthorizationMatrixFolderProperty(List<String> permissions) {
+        for (String permission : permissions) {
+            add(permission);
+        }
     }
 
     @Override
@@ -43,16 +66,33 @@ public class AzureAdAuthorizationMatrixFolderProperty extends AuthorizationMatri
     }
 
     @Extension(optional = true)
-    public static class DescriptorImpl extends AuthorizationMatrixProperty.DescriptorImpl {
+    @Symbol("azureAdAuthorizationMatrix")
+    public static class DescriptorImpl extends AbstractFolderPropertyDescriptor implements
+            AuthorizationPropertyDescriptor<AzureAdAuthorizationMatrixFolderProperty> {
 
         @Override
-        public AuthorizationMatrixProperty create() {
+        public AzureAdAuthorizationMatrixFolderProperty create() {
             return new AzureAdAuthorizationMatrixFolderProperty();
+        }
+
+        @Override
+        public PermissionScope getPermissionScope() {
+            return PermissionScope.ITEM_GROUP;
+        }
+
+        @Override
+        public AuthorizationMatrixProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return createNewInstance(req, formData, true);
         }
 
         @Override
         public boolean isApplicable() {
             return Jenkins.getInstance().getAuthorizationStrategy() instanceof AzureAdMatrixAuthorizationStrategy;
+        }
+
+        @GET
+        public FormValidation doCheckName(@AncestorInPath AbstractFolder<?> folder, @QueryParameter String value) {
+            return doCheckName_(value, folder, Item.CONFIGURE);
         }
 
         @Override

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixFolderProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixFolderProperty.java
@@ -67,6 +67,7 @@ public class AzureAdAuthorizationMatrixFolderProperty extends AuthorizationMatri
 
     @Extension(optional = true)
     @Symbol("azureAdAuthorizationMatrix")
+    @SuppressRestrictedWarnings(AuthorizationPropertyDescriptor.class)
     public static class DescriptorImpl extends AbstractFolderPropertyDescriptor implements
             AuthorizationPropertyDescriptor<AzureAdAuthorizationMatrixFolderProperty> {
 

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixProperty.java
@@ -2,17 +2,33 @@ package com.microsoft.jenkins.azuread;
 
 import hudson.Extension;
 import hudson.model.AutoCompletionCandidates;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
 import hudson.security.AuthorizationMatrixProperty;
 import hudson.security.Permission;
+import hudson.security.PermissionScope;
+import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.matrixauth.AbstractAuthorizationPropertyConverter;
 import org.jenkinsci.plugins.matrixauth.AuthorizationProperty;
+import org.jenkinsci.plugins.matrixauth.AuthorizationPropertyDescriptor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.verb.GET;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,6 +43,15 @@ public class AzureAdAuthorizationMatrixProperty extends AuthorizationMatrixPrope
     public AzureAdAuthorizationMatrixProperty(Map<Permission, Set<String>> grantedPermissions) {
         super(grantedPermissions);
         refreshMap();
+    }
+
+    @DataBoundConstructor
+    @Restricted(NoExternalUse.class)
+    public AzureAdAuthorizationMatrixProperty(List<String> permissions) {
+        this();
+        for (String permission : permissions) {
+            add(permission);
+        }
     }
 
     void refreshMap() {
@@ -67,16 +92,33 @@ public class AzureAdAuthorizationMatrixProperty extends AuthorizationMatrixPrope
     }
 
     @Extension
-    public static class DescriptorImpl extends AuthorizationMatrixProperty.DescriptorImpl {
+    @Symbol("azureAdAuthorizationMatrix")
+    public static class DescriptorImpl extends JobPropertyDescriptor implements
+            AuthorizationPropertyDescriptor<AzureAdAuthorizationMatrixProperty> {
 
         @Override
-        public AuthorizationMatrixProperty create() {
+        public AzureAdAuthorizationMatrixProperty create() {
             return new AzureAdAuthorizationMatrixProperty();
+        }
+
+        @Override
+        public PermissionScope getPermissionScope() {
+            return PermissionScope.ITEM;
+        }
+
+        @Override
+        public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return createNewInstance(req, formData, true);
         }
 
         @Override
         public boolean isApplicable() {
             return Jenkins.getInstance().getAuthorizationStrategy() instanceof AzureAdMatrixAuthorizationStrategy;
+        }
+
+        @GET
+        public FormValidation doCheckName(@AncestorInPath Job<?, ?> project, @QueryParameter String value) {
+            return doCheckName_(value, project, Item.CONFIGURE);
         }
 
         @Nonnull

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixProperty.java
@@ -93,6 +93,7 @@ public class AzureAdAuthorizationMatrixProperty extends AuthorizationMatrixPrope
 
     @Extension
     @Symbol("azureAdAuthorizationMatrix")
+    @SuppressRestrictedWarnings(AuthorizationPropertyDescriptor.class)
     public static class DescriptorImpl extends JobPropertyDescriptor implements
             AuthorizationPropertyDescriptor<AzureAdAuthorizationMatrixProperty> {
 


### PR DESCRIPTION
This PR fixes [JENKINS-64858](https://issues.jenkins.io/browse/JENKINS-64858) enabling the use of the following Job DSL syntax:

```
folder('project-a') {
  displayName('Project A')
  description('Folder for project A')
  properties {
    azureAdAuthorizationMatrix {
      inheritanceStrategy {
        inheriting()
      }
      permissions(['hudson.model.Item.Create:authenticated'])
    }
  }
}


freeStyleJob('project-a/example') {
  properties {
    azureAdAuthorizationMatrix {
      inheritanceStrategy {
        nonInheriting()
      }
      permissions(['hudson.model.Item.Workspace:authenticated'])
    }
  }
}
```