### PR TITLE
fix(email): set Mailer plugin email property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,10 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -33,6 +33,8 @@ import hudson.security.GroupDetails;
 import hudson.security.SecurityRealm;
 import hudson.security.UserMayOrMayNotExistException2;
 import hudson.security.csrf.CrumbExclusion;
+import hudson.tasks.Mailer;
+import hudson.tasks.Mailer.UserProperty;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
@@ -250,7 +252,15 @@ public class AzureSecurityRealm extends SecurityRealm {
                 String description = generateDescription(auth);
                 u.setDescription(description);
                 u.setFullName(auth.getAzureAdUser().getName());
+                if (StringUtils.isNotBlank(auth.getAzureAdUser().getEmail())) {
+                    UserProperty existing = u.getProperty(UserProperty.class);
+                    if (existing == null || !existing.hasExplicitlyConfiguredAddress()) {
+                        u.addProperty(new Mailer.UserProperty(auth.getAzureAdUser().getEmail()));
+                    }
+                }
             }
+
+
             SecurityListener.fireAuthenticated2(userDetails);
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "error", ex);

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -216,7 +216,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     }
 
     public HttpResponse doFinishLogin(StaplerRequest request)
-            throws InvalidJwtException, MalformedClaimException, ExecutionException {
+            throws InvalidJwtException, MalformedClaimException, ExecutionException, IOException {
         try {
             final Long beginTime = (Long) request.getSession().getAttribute(TIMESTAMP_ATTRIBUTE);
             final String expectedNonce = (String) request.getSession().getAttribute(NONCE_ATTRIBUTE);


### PR DESCRIPTION
### Description

This change will set the Mailer.UserProperty on the current user during authentication. The value of the email will be the email configured in the AD.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

Tested on our jenkins instance and it did work as expected.
I had to remove the value that was currently there and the email value got populated during the next login.

Closes https://github.com/jenkinsci/azure-ad-plugin/issues/115