### PR TITLE
Replace deprecated JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixFolderProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixFolderProperty.java
@@ -3,6 +3,7 @@ package com.microsoft.jenkins.azuread;
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.Item;
@@ -23,7 +24,6 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.verb.GET;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 
@@ -97,7 +97,7 @@ public class AzureAdAuthorizationMatrixFolderProperty extends AuthorizationMatri
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Azure Active Directory Authorization Matrix";
         }

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixProperty.java
@@ -1,5 +1,6 @@
 package com.microsoft.jenkins.azuread;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.Item;
@@ -25,7 +26,6 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.verb.GET;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -122,7 +122,7 @@ public class AzureAdAuthorizationMatrixProperty extends AuthorizationMatrixPrope
             return doCheckName_(value, project, Item.CONFIGURE);
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Azure Active Directory Authorization Matrix";

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy.java
@@ -14,6 +14,7 @@ import com.microsoft.graph.options.QueryOption;
 import com.microsoft.graph.requests.GraphServiceClient;
 import com.microsoft.graph.requests.GroupCollectionPage;
 import com.microsoft.graph.requests.UserCollectionPage;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -40,7 +41,6 @@ import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 import org.kohsuke.stapler.QueryParameter;
 import org.springframework.security.core.Authentication;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -62,8 +62,8 @@ public class AzureAdMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
     // Copy codes instead.
     //
     @Override
-    @Nonnull
-    public ACL getACL(@Nonnull Job<?, ?> project) {
+    @NonNull
+    public ACL getACL(@NonNull Job<?, ?> project) {
         AzureAdAuthorizationMatrixProperty amp = project.getProperty(AzureAdAuthorizationMatrixProperty.class);
         if (amp != null) {
             return amp.getInheritanceStrategy().getEffectiveACL(amp.getACL(), project);
@@ -79,7 +79,7 @@ public class AzureAdMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
         }
         return new ACL() {
             @Override
-            public boolean hasPermission2(@Nonnull Authentication a, @Nonnull Permission permission) {
+            public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
                 return a.equals(SYSTEM2) || child.hasPermission2(a, permission) || parent.hasPermission2(a, permission);
             }
         };
@@ -94,8 +94,8 @@ public class AzureAdMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
     }
 
     @Override
-    @Nonnull
-    public ACL getACL(@Nonnull AbstractItem item) {
+    @NonNull
+    public ACL getACL(@NonNull AbstractItem item) {
         if (Jenkins.get().getPlugin("cloudbees-folder") != null) { // optional dependency
             if (item instanceof AbstractFolder) {
                 AzureAdAuthorizationMatrixFolderProperty p =
@@ -109,7 +109,7 @@ public class AzureAdMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
     }
 
     @Override
-    @Nonnull
+    @NonNull
     @SuppressRestrictedWarnings(value = {IdStrategyComparator.class, AuthorizationContainer.class})
     public Set<String> getGroups() {
         Set<String> r = new TreeSet<>(new IdStrategyComparator());
@@ -241,7 +241,7 @@ public class AzureAdMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Azure Active Directory Matrix-based security";
         }

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -24,6 +24,7 @@ import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ProxyConfiguration;
 import hudson.model.Descriptor;
@@ -555,6 +556,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     public static final class DescriptorImpl extends Descriptor<SecurityRealm> {
 
         @Override
+        @NonNull
         public String getDisplayName() {
             return "Azure Active Directory";
         }


### PR DESCRIPTION
Replace deprecated JSR-305 annotations with spotbugs annotations.
In Jenkins Core this was done last year.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
