### PR TITLE
Add support for display name to loadGroupByGroupName

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/utils/UUIDValidator.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/utils/UUIDValidator.java
@@ -1,0 +1,19 @@
+package com.microsoft.jenkins.azuread.utils;
+
+import java.util.regex.Pattern;
+
+public final class UUIDValidator {
+
+    private static final Pattern UUID_REGEX_PATTERN =
+            Pattern.compile("^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$");
+
+    private UUIDValidator() {
+    }
+
+    public static boolean isValidUUID(String str) {
+        if (str == null) {
+            return false;
+        }
+        return UUID_REGEX_PATTERN.matcher(str).matches();
+    }
+}

--- a/src/test/java/com/microsoft/jenkins/azuread/utils/UUIDValidatorTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/utils/UUIDValidatorTest.java
@@ -1,0 +1,22 @@
+package com.microsoft.jenkins.azuread.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UUIDValidatorTest {
+
+    @Test
+    public void is_valid_uuid_true(){
+        assertTrue(UUIDValidator.isValidUUID("009692ee-f930-4a74-bbd0-63b8baa5a927"));
+    }
+    @Test
+    public void is_valid_uuid_false(){
+        assertFalse(UUIDValidator.isValidUUID(null));
+        assertFalse(UUIDValidator.isValidUUID(""));
+        assertFalse(UUIDValidator.isValidUUID("test-ss-ss-ss-s"));
+        assertFalse(UUIDValidator.isValidUUID("009692ee-f9309-4a74-bbd0-63b8baa5a927"));
+        assertFalse(UUIDValidator.isValidUUID("1-1-1-1"));
+    }
+}


### PR DESCRIPTION
I've blocked duplicate groups with the same group name, they will show up as not found

Tested quite a few combinations here including duplicate groups and special characters, seems to be working:

![image](https://user-images.githubusercontent.com/21194782/123228222-35260380-d4cd-11eb-9c88-c945a0372c84.png)

Fixes https://github.com/jenkinsci/azure-ad-plugin/issues/145