### PR TITLE
Trigger re-authentication when id_token missing

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -383,7 +383,10 @@ public class AzureSecurityRealm extends SecurityRealm {
             final String idToken = request.getParameter("id_token");
 
             if (StringUtils.isBlank(idToken)) {
-                throw new IllegalStateException("Can't extract id_token");
+                LOGGER.info("No `id_token` found ensure you have enabled it on the 'Authentication' page of the "
+                        + "app registration");
+                request.getSession().invalidate();
+                return HttpResponses.redirectToContextRoot();
             }
             // validate the nonce to avoid CSRF
             final JwtClaims claims = validateIdToken(expectedNonce, idToken);


### PR DESCRIPTION
We have a proxy in front that forces authentication before the Jenkins authentication, with the SAML plugin this wasn't an issue so may as well make them consistent.

I've added a log message to help administrators in case they haven't enabled `id_token`