### PR TITLE
Store users and groups separately

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>3.0-rc378.1a652f3069a5</version>
+            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.scribejava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
+            <version>3.0-rc378.1a652f3069a5</version>
         </dependency>
         <dependency>
             <groupId>com.github.scribejava</groupId>
@@ -182,7 +183,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAuthenticationToken.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAuthenticationToken.java
@@ -37,9 +37,18 @@ public class AzureAuthenticationToken implements Authentication {
         return null;
     }
 
+
+    private String getObjectId() {
+        return azureAdUser != null ? azureAdUser.getObjectID() : null;
+    }
+
+    private String getDisplayName() {
+        return azureAdUser != null ? azureAdUser.getName() : null;
+    }
+
     @Override
     public Object getPrincipal() {
-        return getName();
+        return String.format("%s (%s)", getDisplayName(), getObjectId());
     }
 
     @Override

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.jelly
@@ -63,6 +63,7 @@ THE SOFTWARE.
         </j:choose>
       </d:tag>
       <d:tag name="row">
+        <j:set var="permissionEntry" value="${descriptor.entryFor(attrs.type, attrs.sid)}"/>
         <j:set var="sid" value="${attrs.sid}"/>
         <j:choose>
           <j:when test="${attrs.sid == 'authenticated'}">
@@ -91,7 +92,7 @@ THE SOFTWARE.
                   data-permission-id="${p.id}"
                   data-tooltip-enabled="${%tooltip_enabled(p.group.title, p.name, attrs.sid)}"
                   data-tooltip-disabled="${%tooltip_disabled(p.group.title, p.name, attrs.sid)}">
-                <f:checkbox name="[${p.id}]" checked="${instance.hasExplicitPermission(attrs.sid,p)}"/>
+                <f:checkbox name="[${p.id}]" checked="${permissionEntry != null and instance.hasExplicitPermission(permissionEntry,p)}"/>
               </td>
             </j:if>
           </j:forEach>
@@ -153,16 +154,16 @@ THE SOFTWARE.
         </j:forEach>
       </tr>
 
-      <tr name="[anonymous]">
+      <tr name="[USER:anonymous]">
         <local:row sid="anonymous" title="${%Anonymous}" />
       </tr>
-      <tr name="[authenticated]">
-        <local:row sid="authenticated" title="authenticated" />
+      <tr name="[GROUP:authenticated]">
+        <local:row type="GROUP" sid="authenticated" title="authenticated" />
       </tr>
-      <j:forEach var="sid" items="${instance.allSIDs}">
-        <j:if test="${sid != 'authenticated'}">
-          <tr name="[${sid}]" class="permission-row" data-descriptor-url="${descriptor.descriptorFullUrl}">
-            <local:row title="${sid}" sid="${sid}"/>
+      <j:forEach var="entry" items="${instance.allPermissionEntries}">
+        <j:if test="${entry.sid != 'authenticated'}">
+          <tr name="[${entry.type}:${entry.sid}]" class="permission-row" data-descriptor-url="${descriptor.descriptorFullUrl}">
+            <local:row title="${entry.sid}" sid="${entry.sid}" type="${entry.type.toString()}" />
           </tr>
         </j:if>
       </j:forEach>
@@ -180,9 +181,15 @@ THE SOFTWARE.
             <j:when test="${descriptor.disableGraphIntegration}">
               <f:textbox field="userOrGroup" id="${id}text"/>
               <div class="no-graph-integration-wrapper">
-                <input type="button" class="azure-ad-add-button" value="${%Add}" id="${id}UserButton"
+                <input type="button" class="azure-ad-add-button" value="${%Add user}" id="${id}UserButton"
                        data-table-id="${id}"
-                       data-message-error="${%error}"
+                       data-type="USER"
+                       data-message-error="${%userError}"
+                />
+                <input type="button" class="azure-ad-add-button" value="${%Add group}" id="${id}GroupButton"
+                       data-table-id="${id}"
+                       data-type="GROUP"
+                       data-message-error="${%groupError}"
                 />
               </div>
               </j:when>
@@ -203,6 +210,11 @@ THE SOFTWARE.
         <div class="validation-error-area tr">
           <div class="azure-ad-validation-error error default-hidden">Please select a user or group.</div>
         </div>
+        <j:if test="${descriptor.hasAmbiguousEntries(instance)}">
+            <div class="alert alert-warning">
+                ${%ambiguous}
+            </div>
+        </j:if>
       <st:adjunct includes="com.microsoft.jenkins.azuread.table"/>
     </local:isEditable>
   </f:block>

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.properties
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.properties
@@ -5,4 +5,13 @@ tooltip_enabled={0}/{1} for {2}
 tooltip_disabled={0}/{1} for {2} is granted through another permission
 prompt=User or group name:
 empty=Please enter a user name or a group name
-error=An entry for this user or group already exists
+
+userError=An entry for this user already exists
+groupError=An entry for this group already exists
+
+ambiguous=This table contains rows with ambiguous entries. This means that they apply to both users \
+   and groups of the specified name. \
+  If the current security realm does not distinguish between user names and group names unambiguously, \
+  and if users can either choose their own user name or create new groups, \
+  this configuration may allow them to obtain greater permissions. \
+  It is recommended that you replace all ambiguous entries with ones that are either explicitly a user or group.

--- a/src/main/resources/com/microsoft/jenkins/azuread/table.js
+++ b/src/main/resources/com/microsoft/jenkins/azuread/table.js
@@ -27,8 +27,12 @@ Behaviour.specify(".azure-ad-add-button", 'AzureAdMatrixAuthorizationStrategy', 
 
         selectedPeople.forEach(function(person) {
             var name = person
+            var type
             if (typeof person !== 'string') {
                 name = person.displayName + " (" + person.id + ")"
+                type = person.groupTypes ? "GROUP" : "USER"
+            } else {
+                type = dataReference.getAttribute('data-type')
             }
 
             if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
@@ -44,7 +48,7 @@ Behaviour.specify(".azure-ad-add-button", 'AzureAdMatrixAuthorizationStrategy', 
             copy.removeAttribute("id");
             copy.classList.remove("default-hidden");
             copy.firstChild.innerHTML = YAHOO.lang.escapeHTML(name); // TODO consider setting innerText
-            copy.setAttribute("name",'['+ name+']');
+            copy.setAttribute("name",'[' + type + ':' + name+']');
 
             for(var child = copy.firstChild; child !== null; child = child.nextSibling) {
                 if (child.hasAttribute('data-permission-id')) {


### PR DESCRIPTION
The plugin we rely on is splitting the storage of users and groups (which is a good thing)

Previously you couldn't differentiate in APIs if an authority was a group or a user. This allows us to call the right APIs rather than calling both.

see
https://github.com/jenkinsci/matrix-auth-plugin/pull/110

Fixes https://github.com/jenkinsci/azure-ad-plugin/issues/123

I've tested this quite extensively but it is a risky change and may affect some setups