### PR TITLE
Adapt icon path removal from weekly 2.333

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "azure-ad-plugin",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>3.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.scribejava</groupId>

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.jelly
@@ -69,14 +69,14 @@ THE SOFTWARE.
           <j:when test="${attrs.sid == 'authenticated'}">
             <td class="left-most">
               <span title="authenticated">
-                <img src="${imagesURL}/16x16/user.png" class="icon-user-or-group-img"/>${%Authenticated Users}
+                <l:icon class="icon-user icon-sm"/>${%Authenticated Users}
               </span>
             </td>
           </j:when>
           <j:when test="${attrs.sid == 'anonymous'}">
             <td class="left-most">
               <span title="anonymous">
-                <img src="${imagesURL}/16x16/user.png" class="icon-user-or-group-img"/>${%Anonymous Users}
+                <l:icon class="icon-user icon-sm"/>${%Anonymous Users}
               </span>
             </td>
           </j:when>
@@ -100,14 +100,14 @@ THE SOFTWARE.
         <local:isEditable>
           <td class="stop azure-ad-controls">
             <a href="#" class="selectall">
-              <img alt="${%Select all}" title="${%selectall(sid)}" src="${rootURL}/plugin/matrix-auth/images/16x16/select-all.png" height="16" width="16"/>
+              <img alt="${%Select all}" title="${%selectall(sid)}" src="${rootURL}/plugin/matrix-auth/images/select-all.svg" style='margin-right:0.2em' height="16" width="16"/>
             </a>
             <a href="#" class="unselectall">
-              <img alt="${%Unselect all}" title="${%unselectall(sid)}" src="${rootURL}/plugin/matrix-auth/images/16x16/unselect-all.png" height="16" width="16"/>
+              <img alt="${%Unselect all}" title="${%unselectall(sid)}" src="${rootURL}/plugin/matrix-auth/images/unselect-all.svg" height="16" width="16"/>
             </a>
             <j:if test="${sid!='anonymous' and sid != 'authenticated'}">
               <a href="#" class="remove">
-                <img alt="${%Remove user/group}" title="${%remove(sid)}" src="${imagesURL}/16x16/stop.png" height="16" width="16"/>
+                <l:icon alt="${%Remove user/group}" title="${%remove(sid)}" class="icon-stop icon-sm" />
               </a>
             </j:if>
           </td>

--- a/src/main/webapp/css/azure-ad.css
+++ b/src/main/webapp/css/azure-ad.css
@@ -1,7 +1,3 @@
-.icon-user-or-group-img {
-    margin-right:0.2em
-}
-
 td.azure-ad-controls {
     text-align: left;
 }


### PR DESCRIPTION
Fix legacy icon removal in weekly 2.333 and adapt the changes of matrix-auth 3.0.1, which contains the updated in-house icons.

Fixes [JENKINS-67707](https://issues.jenkins.io/browse/JENKINS-67707)