### PR TITLE
Fix for AD users that do not have email addresses

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -510,7 +510,7 @@ public class AzureSecurityRealm extends SecurityRealm {
                     List<AzureAdGroup> groups = AzureCachePool.get(azureClient)
                             .getBelongingGroupsByOid(user.getObjectID());
 
-                    user.setAuthorities(groups, user.getEmail());
+                    user.setAuthorities(groups, user.getUniqueName());
                     return user;
                 } catch (GraphServiceException e) {
                     if (e.getResponseCode() == NOT_FOUND) {


### PR DESCRIPTION
Since #249 if an Azure AD user does not have its Email field set, it no longer works, because the email address is expected to be valid and used as the UPN at
https://github.com/jenkinsci/azure-ad-plugin/blob/03cb645a7149e556f01b972e98a16e956f8cece0/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java#L513

The other usage of the same `setAuthorities()` function in that file uses the unique name which seems to be correct.
https://github.com/jenkinsci/azure-ad-plugin/blob/03cb645a7149e556f01b972e98a16e956f8cece0/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java#L402

It is already noted that the email address is not always filled:
https://github.com/jenkinsci/azure-ad-plugin/blob/03cb645a7149e556f01b972e98a16e956f8cece0/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java#L69-L71

This PR fixes the issue by consistently using the Azure AD user's unique name as the UPN.

