### PR TITLE
Make fallback logic use correct SID

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixNodeProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdAuthorizationMatrixNodeProperty.java
@@ -26,6 +26,7 @@ import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -168,7 +169,15 @@ public class AzureAdAuthorizationMatrixNodeProperty extends AuthorizationMatrixN
                 }
 
                 User current = User.current();
-                String sid = current == null ? "anonymous" : current.getId();
+                String sid;
+
+                if (current != null) {
+                    UserDetailsService detailsService = Jenkins.get().getSecurityRealm().getSecurityComponents().userDetails2;
+                    AzureAdUser details = (AzureAdUser) detailsService.loadUserByUsername(current.getId());
+                    sid = ObjId2FullSidMap.generateFullSid(current.getId(), details.getObjectID());
+                } else {
+                    sid = "anonymous";
+                }
 
                 if (!strategy.getACL(node).hasPermission2(Jenkins.getAuthentication2(), Computer.CONFIGURE)) {
                     prop.add(Computer.CONFIGURE, PermissionEntry.user(sid));


### PR DESCRIPTION
When creating a new node, a fallback logic ensures that the user has permissions on the node by adding them to the auth matrix if they didn't add themself. This did not correctly work as only the user principal name was used, but not the object ID.

Fixes https://github.com/jenkinsci/azure-ad-plugin/issues/278

Co-Authored by @StefanSpieker 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

