### PR TITLE
Use filter instead of search for group name match

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -19,7 +19,6 @@ import com.microsoft.graph.authentication.TokenCredentialAuthProvider;
 import com.microsoft.graph.http.GraphServiceException;
 import com.microsoft.graph.httpcore.HttpClients;
 import com.microsoft.graph.models.Group;
-import com.microsoft.graph.options.HeaderOption;
 import com.microsoft.graph.options.Option;
 import com.microsoft.graph.options.QueryOption;
 import com.microsoft.graph.requests.GraphServiceClient;
@@ -592,10 +591,9 @@ public class AzureSecurityRealm extends SecurityRealm {
             LOGGER.log(Level.WARNING, "Failed to url encode query, group name was: " + groupName);
         }
 
-        String query = String.format("\"displayName:%s\"", encodedGroupName);
+        String query = String.format("displayName eq '%s'", encodedGroupName);
 
-        requestOptions.add(new QueryOption("$search", query));
-        requestOptions.add(new HeaderOption("ConsistencyLevel", "eventual"));
+        requestOptions.add(new QueryOption("$filter", query));
 
         GroupCollectionPage groupCollectionPage = getAzureClient().groups()
                 .buildRequest(requestOptions)


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Using role-based authz (or any other that's not the Azure AD Matrix one) results in strange behaviour when there are groups with similar names. Since the graph query is doing a search, it returns entries that are like the specified group, rather than only exact matches.

For example, consider a setup with two groups - `DevOps-PRD` and `DevOps-Admins-PRD`

The following group names would match a single group:
- DevOps-Admins-PRD
- DevOps-Admins (which doesn't exist, but would map to the same UUID as `DevOps-Admins-PRD`)

The following would match multiple groups (and therefore fall over)
- DevOps-PRD

This change makes the group search do an exact match query, resulting in `DevOps-PRD` and `DevOps-Admins-PRD` being matched but `DevOps-Admins` not being matched

Making assumptions as to the cause for this issue, but this may resolve #351

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
