### PR TITLE
Fix ObjId2FullSidMap memory allocations

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/ObjId2FullSidMap.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/ObjId2FullSidMap.java
@@ -24,8 +24,9 @@ public class ObjId2FullSidMap extends HashMap<String, String> {
         if (containsKey(extractedObjectId)) {
             return get(extractedObjectId);
         }
+        String objValuesPrefix = objectId + " (";
         for (String value : values()) {
-            if (value.startsWith(objectId + " (")) {
+            if (value.startsWith(objValuesPrefix)) {
                 return value;
             }
         }


### PR DESCRIPTION
Our team noticed a significant amount of memory churn when using the azure-ad-plugin on big Jenkins instances. Using dynatrace, we traced it down to ObjId2FullSidMap allocating a lot of StringBuilders in a short amount of time.

![image](https://github.com/jenkinsci/azure-ad-plugin/assets/32979435/29eb35b7-1f1d-42d9-8be0-eba119a6ae78)
![image](https://github.com/jenkinsci/azure-ad-plugin/assets/32979435/99650ae1-fac6-4b9b-ac85-955e62a5974e)

### Testing done

Testing was done by deploying the change on some of our instances, improving the situation. Memory allocations could be reduced from 14TB in 2 hrs to about 1.1TB in 2 hrs.

![image](https://github.com/jenkinsci/azure-ad-plugin/assets/32979435/2718526c-8a6c-4453-bb56-fa62b6426ea2)

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [~] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

