### PR TITLE
Use caffeine for storing instances of GraphClient

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/GraphClientCache.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/GraphClientCache.java
@@ -1,0 +1,103 @@
+package com.microsoft.jenkins.azuread;
+
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.microsoft.graph.authentication.TokenCredentialAuthProvider;
+import com.microsoft.graph.httpcore.HttpClients;
+import com.microsoft.graph.requests.GraphServiceClient;
+import hudson.ProxyConfiguration;
+import hudson.util.Secret;
+import io.jenkins.plugins.azuresdk.HttpClientRetriever;
+import jenkins.model.Jenkins;
+import jenkins.util.JenkinsJVM;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.Proxy;
+
+import static com.microsoft.jenkins.azuread.AzureEnvironment.AZURE_PUBLIC_CLOUD;
+import static com.microsoft.jenkins.azuread.AzureEnvironment.getAuthorityHost;
+import static com.microsoft.jenkins.azuread.AzureEnvironment.getServiceRoot;
+
+public class GraphClientCache {
+
+    private static final int TEN = 10;
+    private static final LoadingCache<GraphClientCacheKey, GraphServiceClient<Request>> TOKEN_CACHE = Caffeine.newBuilder()
+            .maximumSize(TEN)
+            .build(GraphClientCache::createGraphClient);
+
+    private static GraphServiceClient<Request> createGraphClient(GraphClientCacheKey key) {
+        final ClientSecretCredential clientSecretCredential = getClientSecretCredential(key);
+
+        final TokenCredentialAuthProvider authProvider = new TokenCredentialAuthProvider(clientSecretCredential);
+
+        OkHttpClient.Builder builder = HttpClients.createDefault(authProvider)
+                .newBuilder();
+
+        builder = addProxyToHttpClientIfRequired(builder);
+        final OkHttpClient graphHttpClient = builder.build();
+
+        GraphServiceClient<Request> graphServiceClient = GraphServiceClient
+                .builder()
+                .httpClient(graphHttpClient)
+                .buildClient();
+
+        String azureEnv = key.getAzureEnvironmentName();
+
+        if (!azureEnv.equals(AZURE_PUBLIC_CLOUD)) {
+            graphServiceClient.setServiceRoot(getServiceRoot(azureEnv));
+        }
+        return graphServiceClient;
+    }
+
+    static ClientSecretCredential getClientSecretCredential(GraphClientCacheKey key) {
+        return new ClientSecretCredentialBuilder()
+                .clientId(key.getClientId())
+                .clientSecret(key.getClientSecret())
+                .tenantId(key.getTenantId())
+                .authorityHost(getAuthorityHost(key.getAzureEnvironmentName()))
+                .httpClient(HttpClientRetriever.get())
+                .build();
+    }
+
+    static GraphServiceClient<Request> getClient(GraphClientCacheKey key) {
+        return TOKEN_CACHE.get(key);
+    }
+
+    public static GraphServiceClient<Request> getClient(AzureSecurityRealm azureSecurityRealm) {
+        GraphClientCacheKey key = new GraphClientCacheKey(
+                azureSecurityRealm.getClientId(),
+                Secret.toString(azureSecurityRealm.getClientSecret()),
+                azureSecurityRealm.getTenant(),
+                azureSecurityRealm.getAzureEnvironmentName()
+        );
+
+        return TOKEN_CACHE.get(key);
+    }
+
+    public static OkHttpClient.Builder addProxyToHttpClientIfRequired(OkHttpClient.Builder builder) {
+        if (JenkinsJVM.isJenkinsJVM()) {
+            ProxyConfiguration proxyConfiguration = Jenkins.get().getProxy();
+            if (proxyConfiguration != null && StringUtils.isNotBlank(proxyConfiguration.getName())) {
+                Proxy proxy = proxyConfiguration.createProxy("graph.microsoft.com");
+
+                builder = builder.proxy(proxy);
+                if (StringUtils.isNotBlank(proxyConfiguration.getUserName())) {
+                    builder = builder.proxyAuthenticator((route, response) -> {
+                        String credential = Credentials.basic(
+                                proxyConfiguration.getUserName(),
+                                proxyConfiguration.getSecretPassword().getPlainText()
+                        );
+                        return response.request().newBuilder().header("Authorization", credential).build();
+                    });
+                }
+            }
+        }
+
+        return builder;
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/azuread/GraphClientCacheKey.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/GraphClientCacheKey.java
@@ -1,0 +1,46 @@
+package com.microsoft.jenkins.azuread;
+
+import java.util.Objects;
+
+class GraphClientCacheKey {
+        private final String clientId;
+        private final String clientSecret;
+        private final String tenantId;
+        private final String azureEnvironmentName;
+
+        public GraphClientCacheKey(String clientId, String clientSecret, String tenantId, String azureEnvironmentName) {
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+            this.tenantId = tenantId;
+            this.azureEnvironmentName = azureEnvironmentName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            GraphClientCacheKey cacheKey = (GraphClientCacheKey) o;
+            return Objects.equals(clientId, cacheKey.clientId) && Objects.equals(clientSecret, cacheKey.clientSecret) && Objects.equals(tenantId, cacheKey.tenantId) && Objects.equals(azureEnvironmentName, cacheKey.azureEnvironmentName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(clientId, clientSecret, tenantId, azureEnvironmentName);
+        }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getAzureEnvironmentName() {
+        return azureEnvironmentName;
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/azuread/GraphProxy.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/GraphProxy.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static com.microsoft.jenkins.azuread.AzureSecurityRealm.addProxyToHttpClientIfRequired;
+import static com.microsoft.jenkins.azuread.GraphClientCache.addProxyToHttpClientIfRequired;
 
 /**
  * Proxies calls to the Microsoft Graph API.

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureAdLogoutAction/index.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureAdLogoutAction/index.jelly
@@ -1,7 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
     <l:layout title="${%Logged out}">
-        <st:include page="sidepanel.jelly" />
         <l:main-panel>
             <h1>${%Logged out}</h1>
             <p>${%You are now logged out of Jenkins}.</p>

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureAdLogoutAction/sidepanel.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureAdLogoutAction/sidepanel.jelly
@@ -1,9 +1,0 @@
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:header />
-    <l:side-panel>
-        <l:tasks>
-            <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
-        </l:tasks>
-    </l:side-panel>
-</j:jelly>

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
@@ -43,7 +43,7 @@
         </f:entry>
         <p>${%Save any configuration changes before configuring authorization settings}</p>
 
-        <f:validateButton title="Verify Application" method="verifyConfiguration" progress="Verifying..." with="clientId,clientSecret,tenant,testObject,azureEnvironmentName"/>
+        <f:validateButton title="Verify configuration" method="verifyConfiguration" progress="Verifying..." with="clientId,clientSecret,tenant,testObject,azureEnvironmentName"/>
 
     </f:block>
 </j:jelly>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Means we don't create a new one whenever someone tests a connection.
Also makes me feel safer about saving the configure page that we won't leave old ones lying around etc.

Some other minor fixes:
- Logout page login link now takes you to the home page
- Removed sidepanel link that is unneeded
- Changed text on verify button

### Testing done

Tested connection
Added new people to matrix

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
