### PR TITLE
Add type prefix to duplicate user check for azure ad matrix

### DIFF
--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.jelly
@@ -191,13 +191,13 @@ THE SOFTWARE.
                      data-table-id="${id}"
                      data-type="USER"
                      data-type-label="${%user}"
-                     data-message-error="${%userError}"
+                     data-message-user-error="${%userError}"
               >${%Add user}</button>
               <button type="button" class="jenkins-button azure-ad-add-button" id="${id}GroupButton"
                      data-table-id="${id}"
                      data-type="GROUP"
                      data-type-label="${%group}"
-                     data-message-error="${%groupError}"
+                     data-message-group-error="${%groupError}"
               >${%Add group}</button>
             </div>
           </j:when>
@@ -209,7 +209,8 @@ THE SOFTWARE.
               <button type="button" class="jenkins-button azure-ad-add-button" id="${id}button"
                      data-table-id="${id}"
                      data-message-empty="${%empty}"
-                     data-message-error="${%error}"
+                     data-message-user-error="${%userError}"
+                     data-message-group-error="${%groupError}"
                      data-type-user-label="${%user}"
                      data-type-group-label="${%user}"
               >${%Add}</button>

--- a/src/main/resources/com/microsoft/jenkins/azuread/Messages.properties
+++ b/src/main/resources/com/microsoft/jenkins/azuread/Messages.properties
@@ -14,7 +14,7 @@ AzureAdLogoutAction_DisplayName=Logged out
 
 GlobalMatrixAuthorizationStrategy.PermissionImpliedBy=This permission is implied by {0}/{1}.
 GlobalMatrixAuthorizationStrategy.PermissionNotImpliedBy=This permission is <strong>not</strong> implied by Overall/Administer. It needs to be explicitly granted even to administrators.
-GlobalMatrixAuthorizationStrategy.DisplayName=Matrix-based security
+GlobalMatrixAuthorizationStrategy.DisplayName=Old AzureAD Matrix-based security (do not use)
 
 AuthorizationMatrixNodeProperty_DisplayName=Enable node-based security
 

--- a/src/main/resources/com/microsoft/jenkins/azuread/table.js
+++ b/src/main/resources/com/microsoft/jenkins/azuread/table.js
@@ -44,8 +44,10 @@ Behaviour.specify(".azure-ad-add-button", 'AzureAdMatrixAuthorizationStrategy', 
                 type = dataReference.getAttribute('data-type')
             }
 
-            if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
-                alert(dataReference.getAttribute('data-message-error') + ": " + name);
+            if (findElementsBySelector(table, "TR").find(function (n) {
+                return n.getAttribute("name") === '[' + type + ':' + name + ']';
+            }) != null) {
+                alert(dataReference.getAttribute(`data-message-${type.toLowerCase()}-error`) + ": " + name);
                 return;
             }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

Added duplicate users and it didn't crash and clear the config on save instead it pops up a dialog (this should be adapted to the new Jenkins dialog APIs on a newer baseline):

![image](https://github.com/jenkinsci/azure-ad-plugin/assets/21194782/2c6fa4dc-bb2a-4e30-9e8c-d5ff9e2719c6)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
