### PR TITLE
 Move invalidating session to doCommenceLogin. Fix first login attemp…

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -307,6 +307,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     public HttpResponse doCommenceLogin(StaplerRequest request, @Header("Referer") final String referer) {
         String trimmedReferrer = getReferer(referer);
 
+        recreateSession(request);
         request.getSession().setAttribute(REFERER_ATTRIBUTE, trimmedReferrer);
         OAuth20Service service = getOAuthService();
         request.getSession().setAttribute(TIMESTAMP_ATTRIBUTE, System.currentTimeMillis());
@@ -351,8 +352,6 @@ public class AzureSecurityRealm extends SecurityRealm {
         try {
             final Long beginTime = (Long) request.getSession().getAttribute(TIMESTAMP_ATTRIBUTE);
             final String expectedNonce = (String) request.getSession().getAttribute(NONCE_ATTRIBUTE);
-
-            recreateSession(request);
 
             if (expectedNonce == null) {
                 // no nonce, probably some issue with an old session, force the user to re-auth


### PR DESCRIPTION
Move session invalidation to doCommenceLogin. Fix first login attempt on Chrome browser after session timeout fails. (#481)


<!-- Please describe your pull request here. -->
The session is invalidated in doFinishLogin, but before, NONCE is read. This resulted in redirecting user to context root as a result of missing NONCE in Chrome browser as described in the issue: 

Fixes https://github.com/jenkinsci/azure-ad-plugin/issues/481

I believe the sesion should be recreated in doCommenceLogin where authorization process begins.


### Testing done
The compiled plugin was installed in Jenkins on localhost.
After change after login user is no longer redirected to context-root, but to the job url he clicked.

The changes has been tested in Chrome (Version 118.0.5993.117 (Official Build) (x86_64) and Firefox (118.0.2 (64-bit))



[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
Running tests for org.jenkins-ci.plugins:azure-ad:9999-SNAPSHOT
[INFO] Running com.microsoft.jenkins.azuread.ObjId2FullSidMapTest
[INFO] Running com.microsoft.jenkins.azuread.utils.UUIDValidatorTest
[INFO] Running com.microsoft.jenkins.azuread.integrations.casc.ConfigAsCodeTest
[INFO] Running com.microsoft.jenkins.azuread.AzureSecurityRealmTest
[INFO] Running com.microsoft.jenkins.azuread.AzureAdConfigurationSaveTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s -- in com.microsoft.jenkins.azuread.utils.UUIDValidatorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s -- in com.microsoft.jenkins.azuread.ObjId2FullSidMapTest
[INFO] Running InjectedTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.74 s -- in com.microsoft.jenkins.azuread.AzureAdConfigurationSaveTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.96 s -- in com.microsoft.jenkins.azuread.integrations.casc.ConfigAsCodeTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.21 s -- in com.microsoft.jenkins.azuread.AzureSecurityRealmTest
[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.75 s -- in InjectedTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- frontend:1.14.0:npm (npm mvntest) @ azure-ad ---
[INFO] Running 'npm run mvntest' in /Users/mlow/workspace/github/azure-ad-plugin
[INFO] 
[INFO] > azure-ad-plugin@1.0.0 mvntest
[INFO] > npm run test
[INFO] 
[INFO] 
[INFO] > azure-ad-plugin@1.0.0 test
[INFO] > echo "Error: no test specified" && exit 0
[INFO] 
[INFO] Error: no test specified
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  55.638 s
[INFO] Finished at: 2023-10-31T15:48:33+01:00
[INFO] ------------------------------------------------------------------------

openjdk version "17.0.8.1" 2023-08-22 LTS
OpenJDK Runtime Environment Corretto-17.0.8.8.1 (build 17.0.8.1+8-LTS)
OpenJDK 64-Bit Server VM Corretto-17.0.8.8.1 (build 17.0.8.1+8-LTS, mixed mode, sharing)

ProductName:            macOS
ProductVersion:         13.4.1
ProductVersionExtra:    (c)
BuildVersion:           22F770820d



```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
