### PR TITLE
Rebrand plugin to Microsoft Entra ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Azure Active Directory Plugin
+# Microsoft Entra ID Plugin (previously Azure Active Directory Plugin)
 
 > ***Important***: This plug-in is maintained by the Jenkins community and won’t be supported by Microsoft as of February 29, 2024.
 
@@ -44,7 +44,7 @@ _Note: You can skip this part and just use the claims returned when authenticati
 
 ## Setup In Jenkins
 
-Click `Manage Jenkins` in the left menu, then click `Configure Global Security`
+Click `Manage Jenkins` in the left menu, then click `Security`
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ***Important***: This plug-in is maintained by the Jenkins community and won’t be supported by Microsoft as of February 29, 2024.
 
-A Jenkins Plugin that supports authentication & authorization via Microsoft Entra ID ([previously known as Azure Active Directory](https://learn.microsoft.com/en-us/entra/fundamentals/new-name)).
+A Jenkins Plugin that supports authentication & authorization via Microsoft Entra ID ([previously known as Azure Active Directory](https://learn.microsoft.com/entra/fundamentals/new-name)).
 
 ## Setup In Microsoft Entra ID
 
@@ -16,11 +16,11 @@ A Jenkins Plugin that supports authentication & authorization via Microsoft Entr
 
 1. Click `Authentication`, under 'Implicit grant and hybrid flows', enable `ID tokens`.
 
-1. (optional) To enable Entra ID group support: Click `Manifest` and modify the `"groupMembershipClaims": null` value to `"groupMembershipClaims": "SecurityGroup"`, then 'Save' it.
+1. (optional) To enable Microsoft Entra ID group support: Click `Manifest` and modify the `"groupMembershipClaims": null` value to `"groupMembershipClaims": "SecurityGroup"`, then 'Save' it.
 
-### Setup Entra ID permissions (optional, but recommended)
+### Setup Microsoft Entra ID permissions (optional, but recommended)
 
-In order for Jenkins to be able to lookup data from Entra ID it needs some Graph API permissions.
+In order for Jenkins to be able to lookup data from Microsoft Entra ID it needs some Graph API permissions.
 
 This is used for:
 
@@ -54,7 +54,7 @@ Click `Manage Jenkins` in the left menu, then click `Configure Global Security`
 
 1. Save the configuration, (logged-in users will have permission to do anything)
 
-1. Log in with Entra ID
+1. Log in with Microsoft Entra ID
 
 1. Return to 'Security' to configure authorization
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > ***Important***: This plug-in is maintained by the Jenkins community and won’t be supported by Microsoft as of February 29, 2024.
 
-A Jenkins Plugin that supports authentication & authorization via Azure Active Directory.
+A Jenkins Plugin that supports authentication & authorization via Microsoft Entra ID ([previously known as Azure Active Directory](https://learn.microsoft.com/en-us/entra/fundamentals/new-name)).
 
-## Setup In Azure Active Directory
+## Setup In Microsoft Entra ID
 
-1. Open `Azure Active Directory`, click `App registrations`
+1. Open `Microsoft Entra ID`, click `App registrations`
 
 1. Click `New registration`
 
@@ -16,11 +16,11 @@ A Jenkins Plugin that supports authentication & authorization via Azure Active D
 
 1. Click `Authentication`, under 'Implicit grant and hybrid flows', enable `ID tokens`.
 
-1. (optional) To enable AzureAD group support: Click `Manifest` and modify the `"groupMembershipClaims": null` value to `"groupMembershipClaims": "SecurityGroup"`, then 'Save' it.
+1. (optional) To enable Entra ID group support: Click `Manifest` and modify the `"groupMembershipClaims": null` value to `"groupMembershipClaims": "SecurityGroup"`, then 'Save' it.
 
-### Setup Azure AD permissions (optional, but recommended)
+### Setup Entra ID permissions (optional, but recommended)
 
-In order for Jenkins to be able to lookup data from Azure AD it needs some Graph API permissions.
+In order for Jenkins to be able to lookup data from Entra ID it needs some Graph API permissions.
 
 This is used for:
 
@@ -44,7 +44,7 @@ _Note: You can skip this part and just use the claims returned when authenticati
 
 ## Setup In Jenkins
 
-Click `Manage Jenkins` in the left menu, then click `Security`
+Click `Manage Jenkins` in the left menu, then click `Configure Global Security`
 
 ## Authentication
 
@@ -54,7 +54,7 @@ Click `Manage Jenkins` in the left menu, then click `Security`
 
 1. Save the configuration, (logged-in users will have permission to do anything)
 
-1. Log in with Azure AD
+1. Log in with Entra ID
 
 1. Return to 'Security' to configure authorization
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>azure-ad</artifactId>
     <version>${changelist}</version>
 
-    <name>Azure AD Plugin</name>
+    <name>Microsoft Entra ID (previously Azure AD) Plugin</name>
     <url>https://github.com/jenkinsci/azure-ad-plugin</url>
 
     <packaging>hpi</packaging>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  A Jenkins authentication &amp; authorization plugin for Azure Active Directory
+  A Jenkins authentication &amp; authorization plugin for Microsoft Entra ID
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  A Jenkins authentication &amp; authorization plugin for Microsoft Entra ID
+  A Jenkins authentication &amp; authorization plugin for Microsoft Entra ID (a.k.a. Azure Active Directory, Azure AD)
 </div>


### PR DESCRIPTION
Azure AD is now named Microsoft Entra ID. This PR adjusts the naming in README. In the future it would be good to also rename plugin UI in Jenkins.

### Testing done

Tested manually by reading the README.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
