### PR TITLE
Add theme manager integration

### DIFF
--- a/src/main/frontend/index.ts
+++ b/src/main/frontend/index.ts
@@ -1,7 +1,31 @@
 import { Providers } from '@microsoft/mgt-element/dist/es6';
 import { ProxyProvider } from '@microsoft/mgt-proxy-provider/dist/es6/ProxyProvider';
 import '@microsoft/mgt-components';
+import { applyTheme } from "@microsoft/mgt-components";
 
+document.addEventListener('DOMContentLoaded', () => {
+    const peoplePicker = document.querySelector(".entra-id-people-picker");
+
+    const anyWindow = window as any;
+
+    function getTheme() {
+        return anyWindow.getThemeManagerProperty('entra-id', 'theme')
+    }
+
+    if (anyWindow.getThemeManagerProperty) {
+        const peopleManagerTheme = getTheme();
+        if (peopleManagerTheme) {
+            const setTheme = () => applyTheme(getTheme(), peoplePicker as HTMLElement);
+            setTheme();
+
+            if (anyWindow.isSystemRespectingTheme) {
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+                    setTheme()
+                });
+            }
+        }
+    }
+})
 const currentUrl = window.location.href
 
 // GraphProxy is either a root action or at the job level

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureAdMatrixAuthorizationStrategy/config.jelly
@@ -203,7 +203,13 @@ THE SOFTWARE.
           </j:when>
           <j:otherwise>
             <div class="mgmt-people-picker-wrapper">
-              <mgt-people-picker type="any" user-type="any" group-type="any" show-max="10" />
+              <mgt-people-picker
+                      class="entra-id-people-picker"
+                      type="any"
+                      user-type="any"
+                      group-type="any"
+                      show-max="10"
+              />
             </div>
             <div class="no-graph-integration-wrapper">
               <button type="button" class="jenkins-button azure-ad-add-button" id="${id}button"

--- a/src/main/webapp/css/azure-ad.css
+++ b/src/main/webapp/css/azure-ad.css
@@ -2,11 +2,6 @@ td.azure-ad-controls {
     text-align: left;
 }
 
-.mgmt-people-picker-wrapper {
-    border: 1px solid var(--input-border);
-    border-radius: 3px
-}
-
 .no-graph-integration-wrapper {
     margin-top: 1rem;
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

see https://github.com/jenkinsci/dark-theme-plugin/pull/439  and https://learn.microsoft.com/en-us/graph/toolkit/customize-components/style

Seems to look good enough, we could fully customise the theme to match the jenkins colours if required but this is less to maintain.

Requires https://github.com/jenkinsci/dark-theme-plugin/releases/tag/409.v1753a_3e30d12

Before:

<img width="1033" alt="image" src="https://github.com/jenkinsci/azure-ad-plugin/assets/21194782/f69c149c-092b-46fd-a233-e2fd00361146">

After:

<img width="827" alt="image" src="https://github.com/jenkinsci/azure-ad-plugin/assets/21194782/1ef1d34a-22bb-4303-841c-8a6a2460fcb6">


### Testing done

Tested with new dark theme interactively on the system security page, see screenshots.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
