### PR TITLE
Add support for prompting user account at each login

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -123,6 +123,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     private static final int BAD_REQUEST = 400;
     public static final String CONVERTER_DISABLE_GRAPH_INTEGRATION = "disableGraphIntegration";
     public static final String CONVERTER_SINGLE_LOGOUT = "singleLogout";
+    public static final String CONVERTER_PROMPT_ACCOUNT = "promptAccount";
     public static final String CONVERTER_ENVIRONMENT_NAME = "environmentName";
 
     private Cache<String, AzureAdUser> caches;
@@ -132,6 +133,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     private Secret tenant;
     private int cacheDuration;
     private boolean fromRequest = false;
+    private boolean promptAccount;
     private boolean singleLogout;
     private boolean disableGraphIntegration;
     private String azureEnvironmentName = "Azure";
@@ -162,6 +164,14 @@ public class AzureSecurityRealm extends SecurityRealm {
                 .build();
     }
 
+    public boolean isPromptAccount() {
+        return promptAccount;
+    }
+
+    @DataBoundSetter
+    public void setPromptAccount(boolean promptAccount) {
+        this.promptAccount = promptAccount;
+    }
 
     public boolean isSingleLogout() {
         return singleLogout;
@@ -317,6 +327,9 @@ public class AzureSecurityRealm extends SecurityRealm {
         Map<String, String> additionalParams = new HashMap<>();
         additionalParams.put("nonce", nonce);
         additionalParams.put("response_mode", "form_post");
+        if (promptAccount) {
+            additionalParams.put("prompt", "select_account");
+        }
 
         return new HttpRedirect(service.getAuthorizationUrl(additionalParams));
     }
@@ -631,6 +644,10 @@ public class AzureSecurityRealm extends SecurityRealm {
             writer.setValue(String.valueOf(realm.isDisableGraphIntegration()));
             writer.endNode();
 
+            writer.startNode(CONVERTER_PROMPT_ACCOUNT);
+            writer.setValue(String.valueOf(realm.isPromptAccount()));
+            writer.endNode();
+
             writer.startNode(CONVERTER_SINGLE_LOGOUT);
             writer.setValue(String.valueOf(realm.isSingleLogout()));
             writer.endNode();
@@ -664,6 +681,9 @@ public class AzureSecurityRealm extends SecurityRealm {
                         break;
                     case CONVERTER_DISABLE_GRAPH_INTEGRATION:
                         realm.setDisableGraphIntegration(Boolean.parseBoolean(value));
+                        break;
+                    case CONVERTER_PROMPT_ACCOUNT:
+                        realm.setPromptAccount(Boolean.parseBoolean(value));
                         break;
                     case CONVERTER_SINGLE_LOGOUT:
                         realm.setSingleLogout(Boolean.parseBoolean(value));

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
@@ -30,6 +30,10 @@
             <f:checkbox />
         </f:entry>
 
+        <f:entry title="${%Prompt for user account on each login}" field="promptAccount">
+            <f:checkbox />
+        </f:entry>
+
         <f:entry title="${%Enable Single Logout}" field="singleLogout">
             <f:checkbox />
         </f:entry>


### PR DESCRIPTION
This is a PR to solve my issue https://github.com/jenkinsci/azure-ad-plugin/issues/533. This change was made fairly naively by looking at the other settings available, copy pasting, and adding an if statement in (hopefully) the right place. As mentioned in my issue, I have little experience with Jenkins plug-ins, so forgive me and guide me if I did something dumb here.

### Testing done

~I have not yet tested this, I'm looking in to how to manually build and install the plugin for testing. I'll also go back and look if there's automated testing that could be extended for this.~

I took the .hpi file built by the Jenkins CI process for this PR, spun up a new Jenkins instance in docker with the PR .hpi installed, and checked the behavior:

1. when "Prompt for user account on each login" is _unchecked_, Entra ID automatically uses the MS account attached to windows, without prompting.
2. when "Prompt for user account on each login" is _checked_, Entra ID prompts me for which account to sign in to every time I click "Sign in"

This is successful testing as far as the functionality I need.

I do not see a straightforward way to add a test case (the tests are quite minimal unless I'm missing something).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
