### PR TITLE
Remove access modifier from JPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,16 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>access-modifier-suppressions</artifactId>
-            <!-- needs to be kept in sync with Jenkins core -->
-            <version>1.33</version>
+            <version>${access-modifier-checker.version}</version>
+            <!-- Not needed at runtime -->
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- Upper bounds and comes from core -->
+                    <groupId>org.kohsuke</groupId>
+                    <artifactId>access-modifier-annotation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
This plugin is bundling the following unnecessary JARs into the plugin JPI:

```
[INFO] Bundling direct dependency access-modifier-annotation-1.33.jar
[INFO] Bundling direct dependency access-modifier-suppressions-1.33.jar
```

### Testing done

Verified the JARs are no longer bundled during a plugin build.