### PR TITLE
Use gson-api-plugin and update to Jenkins 2.414.3 and minor updates and improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.74</version>
+        <version>4.80</version>
     </parent>
 
     <artifactId>azure-ad</artifactId>
@@ -36,9 +36,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jenkins.version>2.387.3</jenkins.version>
-        <node.version>18.12.1</node.version>
-        <npm.version>8.19.2</npm.version>
+        <jenkins.version>2.401.3</jenkins.version>
+        <node.version>20.12.1</node.version>
+        <npm.version>10.5.0</npm.version>
         <hpi.compatibleSinceVersion>391.v252da_e1dd39c</hpi.compatibleSinceVersion>
 
         <checkstyle.skip>true</checkstyle.skip>
@@ -103,6 +103,14 @@
                     <groupId>com.azure</groupId>
                     <artifactId>azure-identity</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
                 <!-- Comes from Azure SDK plugin -->
                 <exclusion>
                     <groupId>com.azure</groupId>
@@ -114,7 +122,10 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>commons-lang3-api</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>gson-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>okhttp-api</artifactId>
@@ -171,7 +182,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.scribejava</groupId>
@@ -211,11 +221,6 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
@@ -243,8 +248,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2543.vfb_1a_5fb_9496d</version>
+                <artifactId>bom-2.401.x</artifactId>
+                <version>2745.vc7b_fe4c876fa_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jenkins.version>2.401.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <node.version>20.12.1</node.version>
         <npm.version>10.5.0</npm.version>
         <hpi.compatibleSinceVersion>391.v252da_e1dd39c</hpi.compatibleSinceVersion>
@@ -248,8 +248,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.401.x</artifactId>
-                <version>2745.vc7b_fe4c876fa_</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2950.va_633b_f42f759</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Use [gson-api-plugin](https://plugins.jenkins.io/gson-api/) as suggested by (https://github.com/jenkinsci/azure-ad-plugin/issues/549)
and updated:
* Node to latest LTS (20.12.1)
* NPM to the bundled version (10.5.0)
* Jenkins to version 2.414.3 (because the bom has a version for _gson-api_ and a recent _matrix-auth_ version)
* Plugin to 4.80 (supersedes #507)
* ran `npm audit fix`

and minor improvements
* removed explicit version of matrix-auth, because 3.2.1 seems to be sufficient
* removed explicit test dependency of JUnit 4

<!-- Please describe your pull request here. -->

### Testing done
* Maven install locally passes. 
* Started an interactive debugging session, but did not really connect to an Entra ID instance. Just checked the configure screen and the try connect button.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
