### PR TITLE
Optimize ObjId2FullSidMap::extractObjectId

### DIFF
--- a/src/test/java/com/microsoft/jenkins/azuread/ObjId2FullSidMapTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/ObjId2FullSidMapTest.java
@@ -1,7 +1,11 @@
 package com.microsoft.jenkins.azuread;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ObjId2FullSidMapTest {
 
@@ -29,4 +33,49 @@ public class ObjId2FullSidMapTest {
         Assert.assertEquals(FULL_SID_1, map.getOrOriginal(ObjId2FullSidMap.generateFullSid(NAME_1, OBJECT_ID_1)));
         Assert.assertEquals("some string", map.getOrOriginal("some string"));
     }
+
+    @Test
+    public void testExtractObjectId() {
+        Assert.assertNull(ObjId2FullSidMap.extractObjectId(""));
+        Assert.assertNull(ObjId2FullSidMap.extractObjectId("some string"));
+        Assert.assertNull(ObjId2FullSidMap.extractObjectId("email (id) "));
+        Assert.assertNull(ObjId2FullSidMap.extractObjectId("email (id"));
+        Assert.assertNull(ObjId2FullSidMap.extractObjectId("email id)"));
+        Assert.assertNull(ObjId2FullSidMap.extractObjectId("email(id)"));
+        Assert.assertEquals("id", ObjId2FullSidMap.extractObjectId("email (id)"));
+        Assert.assertEquals("", ObjId2FullSidMap.extractObjectId("email ()"));
+        Assert.assertEquals("id", ObjId2FullSidMap.extractObjectId(" (id)"));
+    }
+
+    @Ignore
+    @Test
+    public void testExtractObjectIdPerformance() throws Exception {
+        final int numWarmupIterations = 1_000_000;
+        final int numExperiments = 1000;
+        final int numIterations = 10000;
+
+        final String fullSid = ObjId2FullSidMap.generateFullSid(EMAIL_1, OBJECT_ID_1);
+
+        // warmup
+        for (int i = 0; i < numWarmupIterations; i++) {
+            ObjId2FullSidMap.extractObjectId(fullSid);
+        }
+        // allow async JIT compilation to catch up
+        Thread.sleep(100);
+
+        List<Long> durationsNanos = new ArrayList<>();
+        for (int r = 0; r < numExperiments; r++) {
+            long start = System.nanoTime();
+            for (int i = 0; i < numIterations; i++) {
+                ObjId2FullSidMap.extractObjectId(fullSid);
+            }
+            long durationNanos = (System.nanoTime() - start) / numIterations;
+            durationsNanos.add(durationNanos);
+        }
+        durationsNanos.sort(null);
+        long median = durationsNanos.get(durationsNanos.size() / 2);
+
+        System.out.println("Median duration per call (nanos): " + median);
+    }
+
 }


### PR DESCRIPTION
Monitoring of one of our Jenkins instances showed that `ObjId2FullSidMap::extractObjectId` was a major CPU hotspot.

![image](https://github.com/user-attachments/assets/ceeb98be-61df-499f-bd0b-b4c2001e7105)

This PR attempts to make the code significantly faster.

### Testing done

The change was tested with the newly created functional test (`ObjId2FullSidMapTest::testExtractObjectId`) and the newly created microbenchmark (`ObjId2FullSidMapTest::testExtractObjectIdPerformance`).

On my local machine the benchmark reported the following with the original code:

```
Median duration per call (nanos): 981
```

With the new code the benchmark reports:

```
Median duration per call (nanos): 34
```

So, this suggest that the new code is roughly 28 times faster than the previous one for typical input. 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
