### PR TITLE
feat: optionally add domain_hint

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -121,6 +121,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     public static final String CONVERTER_DISABLE_GRAPH_INTEGRATION = "disableGraphIntegration";
     public static final String CONVERTER_SINGLE_LOGOUT = "singleLogout";
     public static final String CONVERTER_PROMPT_ACCOUNT = "promptAccount";
+    public static final String CONVERTER_DOMAIN_HINT = "domainHint";
 
     public static final String CONVERTER_ENVIRONMENT_NAME = "environmentName";
 
@@ -137,6 +138,7 @@ public class AzureSecurityRealm extends SecurityRealm {
     private boolean disableGraphIntegration;
     private String azureEnvironmentName = "Azure";
     private String credentialType = "Secret";
+    private String domainHint = "";
 
     public AccessToken getAccessToken() {
         TokenRequestContext tokenRequestContext = new TokenRequestContext();
@@ -190,6 +192,15 @@ public class AzureSecurityRealm extends SecurityRealm {
     @DataBoundSetter
     public void setPromptAccount(boolean promptAccount) {
         this.promptAccount = promptAccount;
+    }
+
+    public String getDomainHint() {
+        return domainHint;
+    }
+
+    @DataBoundSetter
+    public void setDomainHint(String domainHint) {
+        this.domainHint = domainHint;
     }
 
     public boolean isSingleLogout() {
@@ -370,6 +381,9 @@ public class AzureSecurityRealm extends SecurityRealm {
         additionalParams.put("response_mode", "form_post");
         if (promptAccount) {
             additionalParams.put("prompt", "select_account");
+        }
+        if (!StringUtils.isBlank(domainHint)) {
+            additionalParams.put("domain_hint", domainHint);
         }
 
         return new HttpRedirect(service.getAuthorizationUrl(additionalParams));
@@ -702,6 +716,10 @@ public class AzureSecurityRealm extends SecurityRealm {
             writer.startNode(CONVERTER_SINGLE_LOGOUT);
             writer.setValue(String.valueOf(realm.isSingleLogout()));
             writer.endNode();
+
+            writer.startNode(CONVERTER_DOMAIN_HINT);
+            writer.setValue(String.valueOf(realm.getDomainHint()));
+            writer.endNode();
         }
 
         @Override
@@ -744,6 +762,9 @@ public class AzureSecurityRealm extends SecurityRealm {
                         break;
                     case CONVERTER_SINGLE_LOGOUT:
                         realm.setSingleLogout(Boolean.parseBoolean(value));
+                        break;
+                    case CONVERTER_DOMAIN_HINT:
+                        realm.setDomainHint(value);
                         break;
                     default:
                         break;

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
@@ -30,33 +30,35 @@
             <f:textbox />
         </f:entry>
 
-        <f:entry title="${%Azure Environment}" field="azureEnvironmentName">
-            <f:select/>
-        </f:entry>
+        <f:advanced>
+            <f:entry title="${%Azure Environment}" field="azureEnvironmentName">
+                <f:select/>
+            </f:entry>
+            <f:entry title="Cache Duration" field="cacheDuration">
+                <f:number default="3600"/>
+            </f:entry>
 
-        <f:entry title="Cache Duration" field="cacheDuration">
-            <f:number default="3600" />
-        </f:entry>
+            <f:entry title="Callback URL from request" field="fromRequest">
+                <f:checkbox/>
+            </f:entry>
 
-        <f:entry title="Callback URL from request" field="fromRequest">
-            <f:checkbox />
-        </f:entry>
+            <f:entry title="${%Prompt for user account on each login}" field="promptAccount">
+                <f:checkbox/>
+            </f:entry>
 
-        <f:entry title="${%Prompt for user account on each login}" field="promptAccount">
-            <f:checkbox />
-        </f:entry>
+            <f:entry title="${%Domain Hint}" description="${%The realm of the user in a federated directory}"
+                     field="domainHint">
+                <f:textbox/>
+            </f:entry>
 
-        <f:entry title="${%Domain Hint: The realm of the user in a federated directory}" field="domainHint">
-            <f:textbox />
-        </f:entry>
+            <f:entry title="${%Enable Single Logout}" field="singleLogout">
+                <f:checkbox/>
+            </f:entry>
 
-        <f:entry title="${%Enable Single Logout}" field="singleLogout">
-            <f:checkbox />
-        </f:entry>
-
-        <f:entry title="${%Disable graph integration}" field="disableGraphIntegration">
-            <f:checkbox />
-        </f:entry>
+            <f:entry title="${%Disable graph integration}" field="disableGraphIntegration">
+                <f:checkbox/>
+            </f:entry>
+        </f:advanced>
 
         <f:entry title="Test user principal name or object id">
             <f:textbox name="testObject" />

--- a/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/azuread/AzureSecurityRealm/config.jelly
@@ -46,6 +46,9 @@
             <f:checkbox />
         </f:entry>
 
+        <f:entry title="${%Domain Hint: The realm of the user in a federated directory}" field="domainHint">
+            <f:textbox />
+        </f:entry>
 
         <f:entry title="${%Enable Single Logout}" field="singleLogout">
             <f:checkbox />


### PR DESCRIPTION
Providing a domain hint allows to bypass the account selector on Microsoft side in case more than one account has been used in the Browser in the past. Documentation for the parameter is [here](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#send-the-sign-in-request).

### Testing done

I locally built the plugin and installed the hpi file into a Jenkins 2.462.1. After adding our domain to the new input field I opened a separate browser. There the user account selector was bypassed and I got logged directly into Jenkins.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I don't know how and where to add a test for the feature.

Please consider to merge and release a new plugin version.

Thanks,
Gregor