### PR TITLE
AzureAdUser#authorities shouldn't be transient

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureAdUser.java
@@ -15,8 +15,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -40,15 +38,9 @@ public final class AzureAdUser implements UserDetails {
 
     private List<String> groupOIDs;
 
-    private transient volatile List<GrantedAuthority> authorities;
+    private volatile List<GrantedAuthority> authorities;
 
     private AzureAdUser() {
-        authorities = Collections.singletonList(SecurityRealm.AUTHENTICATED_AUTHORITY2);
-    }
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        in.defaultReadObject();
-
         authorities = Collections.singletonList(SecurityRealm.AUTHENTICATED_AUTHORITY2);
     }
 


### PR DESCRIPTION
Implementations of `UserDetails` are expected to be serialized in http session.

In OSS Jenkins this may not be a problem because there is only one node and the session is never deserialized, however in CloudBees CI HA, the session is clustered so serialization/deserialization must work.

The current implementation clears any authorities upon serialization.

I'm not clear why the implementation was this way from the plugin inception. If the size of the session is a concern, then maybe `AzureAdUser` could call directly `AzureCachePool.get(getAzureClient()).getBelongingGroupsByOid(user.getObjectID());` through a method called during deserialization (such as `readResolve` or `readObject`).

<!-- Please describe your pull request here. -->

### Testing done

This patch was tested successfully by one of my customers running CloudBees CI HA with Entra ID. Before the patch, roaming between different runtimes in the cluster would cause the user to lose its group membership, requiring a new login cycle, whereas with this patch, groups are retained and everything works as expected.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
