### PR TITLE
Replaced deprecated stringutils method and minor cleanup

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AuthorizationContainerDescriptor.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AuthorizationContainerDescriptor.java
@@ -46,13 +46,13 @@ public interface AuthorizationContainerDescriptor {
             // only annotate permissions that aren't Administer
             if (impliedBy == null) {
                 // this permission is not implied by anything else, this is notable
-                if (description.length() > 0) {
+                if (!description.isEmpty()) {
                     description += "<br/><br/>";
                 }
                 description += Messages.GlobalMatrixAuthorizationStrategy_PermissionNotImpliedBy();
             } else if (impliedBy != Jenkins.ADMINISTER) {
                 // this is implied by a permission other than Administer
-                if (description.length() > 0) {
+                if (!description.isEmpty()) {
                     description += "<br/><br/>";
                 }
                 description += Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(

--- a/src/main/java/com/microsoft/jenkins/azuread/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AuthorizationMatrixNodeProperty.java
@@ -25,7 +25,6 @@ package com.microsoft.jenkins.azuread;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Node;
@@ -213,7 +212,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
                 if (!strategy.getACL(node).hasPermission2(Jenkins.getAuthentication2(), Computer.CONFIGURE)) {
                     prop.add(Computer.CONFIGURE, PermissionEntry.user(sid));
                 }
-                if (prop.getGrantedPermissionEntries().size() > 0) {
+                if (!prop.getGrantedPermissionEntries().isEmpty()) {
                     try {
                         node.getNodeProperties().replace(prop);
                     } catch (IOException ex) {

--- a/src/main/java/com/microsoft/jenkins/azuread/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AuthorizationMatrixProperty.java
@@ -24,7 +24,6 @@
 package com.microsoft.jenkins.azuread;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -295,7 +294,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
                     if (!strategy.getACL(job).hasPermission2(Jenkins.getAuthentication2(), Item.CONFIGURE)) {
                         prop.add(Item.CONFIGURE, new PermissionEntry(AuthorizationType.USER, sid));
                     }
-                    if (prop.getGrantedPermissionEntries().size() > 0) {
+                    if (!prop.getGrantedPermissionEntries().isEmpty()) {
                         try {
                             if (propIsNew) {
                                 job.addProperty(prop);

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureSecurityRealm.java
@@ -86,7 +86,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -681,11 +680,7 @@ public class AzureSecurityRealm extends SecurityRealm {
         LinkedList<Option> requestOptions = new LinkedList<>();
         String encodedGroupName = groupName
                 .replace("'", "''");
-        try {
-            encodedGroupName = URLEncoder.encode(encodedGroupName, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.log(Level.WARNING, "Failed to url encode query, group name was: " + groupName);
-        }
+        encodedGroupName = URLEncoder.encode(encodedGroupName, StandardCharsets.UTF_8);
 
         String query = String.format("displayName eq '%s'", encodedGroupName);
 

--- a/src/main/java/com/microsoft/jenkins/azuread/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/GlobalMatrixAuthorizationStrategy.java
@@ -25,7 +25,6 @@ package com.microsoft.jenkins.azuread;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.PluginManager;
 import hudson.model.Descriptor;

--- a/src/main/java/com/microsoft/jenkins/azuread/GraphClientCache.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/GraphClientCache.java
@@ -14,7 +14,6 @@ import hudson.ProxyConfiguration;
 import hudson.util.Secret;
 import io.jenkins.plugins.azuresdk.HttpClientRetriever;
 import java.net.URI;
-import java.util.Collections;
 import jenkins.model.Jenkins;
 import jenkins.util.JenkinsJVM;
 import okhttp3.Credentials;

--- a/src/main/java/com/microsoft/jenkins/azuread/GraphProxy.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/GraphProxy.java
@@ -21,6 +21,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerProxy;
@@ -238,7 +239,7 @@ public class GraphProxy implements RootAction, StaplerProxy {
 
         StringBuilder builder = new StringBuilder(apiUrl);
 
-        String path = StringUtils.removeStart(request.getRestOfPath(), "/v1.0");
+        String path = Strings.CS.removeStart(request.getRestOfPath(), "/v1.0");
 
         // /me doesn't work for service principals but we can use the current logged in user instead
         // this is also used for /me/people to get the people the current logged in user works with

--- a/src/main/java/com/microsoft/jenkins/azuread/ValidationUtil.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/ValidationUtil.java
@@ -23,7 +23,6 @@
  */
 package com.microsoft.jenkins.azuread;
 
-import com.microsoft.jenkins.azuread.AuthorizationType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
 import hudson.Util;
@@ -37,7 +36,6 @@ import org.jenkins.ui.symbol.SymbolRequest;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import static com.microsoft.jenkins.azuread.AuthorizationType.EITHER;

--- a/src/main/java/com/microsoft/jenkins/azuread/avatar/EntraAvatarProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/avatar/EntraAvatarProperty.java
@@ -55,7 +55,7 @@ public class EntraAvatarProperty extends UserProperty implements Action {
             return;
         }
 
-        try (FileInputStream fileInputStream = new FileInputStream(file); ) {
+        try (FileInputStream fileInputStream = new FileInputStream(file)) {
             rsp.setContentType(avatarImage.mimeType);
             rsp.serveFile(
                     req, fileInputStream, file.lastModified(), file.length(), imageFileName);

--- a/src/main/java/com/microsoft/jenkins/azuread/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/folder/properties/AuthorizationMatrixProperty.java
@@ -255,7 +255,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
                             .hasPermission2(Jenkins.getAuthentication2(), Item.CONFIGURE)) {
                         prop.add(Item.CONFIGURE, PermissionEntry.user(sid));
                     }
-                    if (prop.getGrantedPermissionEntries().size() > 0) {
+                    if (!prop.getGrantedPermissionEntries().isEmpty()) {
                         try {
                             if (propIsNew) {
                                 folder.addProperty(prop);


### PR DESCRIPTION
Replaced deprecated stringutils method and minor cleanup:
* removed unused imports
* use `isEmpty()` instead of `.length() >0` or `.size() > 0`

### Testing done

local build and test and started in local debugger with `hpi:run`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
