### PR TITLE
Fix commenceLogin without Referer header

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/oauth/StateCache.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/oauth/StateCache.java
@@ -15,7 +15,8 @@ public class StateCache {
             .build();
 
     public String generateValue(HttpSession session) {
-        final String referer = session.getAttribute(AzureSecurityRealm.REFERER_ATTRIBUTE).toString();
+        Object refererAttribute = session.getAttribute(AzureSecurityRealm.REFERER_ATTRIBUTE);
+        final String referer = refererAttribute == null ? null : refererAttribute.toString();
         final Long beginTime = (Long) session.getAttribute(AzureSecurityRealm.TIMESTAMP_ATTRIBUTE);
         final String nonce = session.getAttribute(AzureSecurityRealm.NONCE_ATTRIBUTE).toString();
 

--- a/src/test/java/com/microsoft/jenkins/azuread/oauth/StateCacheTest.java
+++ b/src/test/java/com/microsoft/jenkins/azuread/oauth/StateCacheTest.java
@@ -1,0 +1,68 @@
+package com.microsoft.jenkins.azuread.oauth;
+
+import com.microsoft.jenkins.azuread.AzureSecurityRealm;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class StateCacheTest {
+
+    @AfterEach
+    void clearCache() {
+        StateCache.CACHE.invalidateAll();
+    }
+
+    @Test
+    void generateValueAllowsMissingReferer() {
+        HttpSession session = sessionWith(null, 123L, "nonce");
+
+        String state = new StateCache().generateValue(session);
+
+        StateCache.CacheHolder holder = StateCache.CACHE.getIfPresent(state);
+        assertNotNull(holder);
+        assertNull(holder.referrer());
+        assertEquals(123L, holder.beginTime());
+        assertEquals("nonce", holder.nonce());
+    }
+
+    @Test
+    void generateValueStoresRefererWhenPresent() {
+        HttpSession session = sessionWith("https://jenkins.example/job/example/", 456L, "other-nonce");
+
+        String state = new StateCache().generateValue(session);
+
+        StateCache.CacheHolder holder = StateCache.CACHE.getIfPresent(state);
+        assertNotNull(holder);
+        assertEquals("https://jenkins.example/job/example/", holder.referrer());
+        assertEquals(456L, holder.beginTime());
+        assertEquals("other-nonce", holder.nonce());
+    }
+
+    private static HttpSession sessionWith(String referer, long beginTime, String nonce) {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put(AzureSecurityRealm.REFERER_ATTRIBUTE, referer);
+        attributes.put(AzureSecurityRealm.TIMESTAMP_ATTRIBUTE, beginTime);
+        attributes.put(AzureSecurityRealm.NONCE_ATTRIBUTE, nonce);
+
+        return (HttpSession) Proxy.newProxyInstance(
+                HttpSession.class.getClassLoader(),
+                new Class<?>[]{HttpSession.class},
+                (proxy, method, args) -> {
+                    return switch (method.getName()) {
+                        case "getAttribute" -> attributes.get(args[0]);
+                        case "toString" -> "StateCacheTestHttpSession";
+                        case "hashCode" -> System.identityHashCode(proxy);
+                        case "equals" -> proxy == args[0];
+                        default -> throw new UnsupportedOperationException(method.getName());
+                    };
+                });
+    }
+}


### PR DESCRIPTION
Fixes #791

## What changed
- Handles a missing `Referer` session attribute when generating OAuth state.
- Preserves a null referrer so the existing finish-login fallback redirect can handle it.
- Adds `StateCache` coverage for both missing and present `Referer` values.

## Testing
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home /opt/homebrew/bin/mvn -Dtest=com.microsoft.jenkins.azuread.oauth.StateCacheTest -Dfrontend.skip=true -Dskip.npm=true -Dmaven.wagon.http.retryHandler.count=5 test`

Note: my first Maven run failed before tests because Jenkins' artifact backend stopped responding while resolving `branch-api`. The retry succeeded and ran the focused test class: 2 tests, 0 failures.
