### PR TITLE
Prevent caching of empty group lists on transient API failures

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azuread/AzureCachePool.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureCachePool.java
@@ -32,55 +32,58 @@ public final class AzureCachePool {
     }
 
     public List<AzureAdGroup> getBelongingGroupsByOid(final String oid) {
-        List<AzureAdGroup> result = belongingGroupsByOid.get(oid,
-                (cacheKey) -> {
-                    try {
-                        DirectoryObjectCollectionWithReferencesPage collection = azure
-                                .users(oid)
-                                // TODO asGroup isn't working json error, and neither is $filter on securityEnabled
-                                .transitiveMemberOf()
-                                .buildRequest()
-                                .get();
-
-
-                        List<AzureAdGroup> groups = new ArrayList<>();
-
-                        while (collection != null) {
-                            final List<DirectoryObject> directoryObjects = collection.getCurrentPage();
-
-                            List<AzureAdGroup> groupsFromPage = directoryObjects.stream()
-                                    .map(group -> {
-                                        if (group instanceof Group) {
-                                            return new AzureAdGroup(group.id, ((Group) group).displayName);
-                                        }
-                                        return null;
-                                    })
-                                    .filter(Objects::nonNull)
-                                    .toList();
-                            groups.addAll(groupsFromPage);
-
-                            DirectoryObjectCollectionWithReferencesRequestBuilder nextPage = collection
-                                    .getNextPage();
-                            if (nextPage == null) {
-                                break;
-                            } else {
-                                collection = nextPage.buildRequest().get();
-                            }
-                        }
-
-                        return groups;
-                    } catch (Exception e) {
-                        LOGGER.log(Level.WARNING, "Do not have sufficient privileges to "
-                                + "fetch your belonging groups' authorities.", e);
-                        return Collections.emptyList();
-                    }
-
-                });
-        if (Constants.DEBUG) {
-            belongingGroupsByOid.invalidate(oid);
+        List<AzureAdGroup> cachedResult = belongingGroupsByOid.getIfPresent(oid);
+        if (cachedResult != null) {
+            return cachedResult;
         }
-        return result;
 
+        try {
+            DirectoryObjectCollectionWithReferencesPage collection = azure
+                    .users(oid)
+                    // TODO asGroup isn't working json error, and neither is $filter on securityEnabled
+                    .transitiveMemberOf()
+                    .buildRequest()
+                    .get();
+
+            List<AzureAdGroup> groups = new ArrayList<>();
+
+            while (collection != null) {
+                final List<DirectoryObject> directoryObjects = collection.getCurrentPage();
+
+                List<AzureAdGroup> groupsFromPage = directoryObjects.stream()
+                        .map(group -> {
+                            if (group instanceof Group) {
+                                return new AzureAdGroup(group.id, ((Group) group).displayName);
+                            }
+                            return null;
+                        })
+                        .filter(Objects::nonNull)
+                        .toList();
+                groups.addAll(groupsFromPage);
+
+                DirectoryObjectCollectionWithReferencesRequestBuilder nextPage = collection
+                        .getNextPage();
+                if (nextPage == null) {
+                    break;
+                } else {
+                    collection = nextPage.buildRequest().get();
+                }
+            }
+
+            // Only cache successful results
+            belongingGroupsByOid.put(oid, groups);
+
+            if (Constants.DEBUG) {
+                belongingGroupsByOid.invalidate(oid);
+            }
+
+            return groups;
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Do not have sufficient privileges to "
+                    + "fetch your belonging groups' authorities.", e);
+            // Return empty list but DO NOT cache it - let the next request try again
+            return Collections.emptyList();
+        }
     }
 
     public static void invalidateBelongingGroupsByOid(String userId) {

--- a/src/main/java/com/microsoft/jenkins/azuread/AzureCachePool.java
+++ b/src/main/java/com/microsoft/jenkins/azuread/AzureCachePool.java
@@ -2,6 +2,7 @@ package com.microsoft.jenkins.azuread;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.microsoft.graph.http.GraphServiceException;
 import com.microsoft.graph.models.DirectoryObject;
 import com.microsoft.graph.models.Group;
 import com.microsoft.graph.requests.DirectoryObjectCollectionWithReferencesPage;
@@ -16,6 +17,8 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 
 public final class AzureCachePool {
     private static final Logger LOGGER = Logger.getLogger(AzureCachePool.class.getName());
@@ -32,58 +35,62 @@ public final class AzureCachePool {
     }
 
     public List<AzureAdGroup> getBelongingGroupsByOid(final String oid) {
-        List<AzureAdGroup> cachedResult = belongingGroupsByOid.getIfPresent(oid);
-        if (cachedResult != null) {
-            return cachedResult;
-        }
+        List<AzureAdGroup> result = belongingGroupsByOid.get(oid,
+                (cacheKey) -> {
+                    try {
+                        DirectoryObjectCollectionWithReferencesPage collection = azure
+                                .users(oid)
+                                // TODO asGroup isn't working json error, and neither is $filter on securityEnabled
+                                .transitiveMemberOf()
+                                .buildRequest()
+                                .get();
 
-        try {
-            DirectoryObjectCollectionWithReferencesPage collection = azure
-                    .users(oid)
-                    // TODO asGroup isn't working json error, and neither is $filter on securityEnabled
-                    .transitiveMemberOf()
-                    .buildRequest()
-                    .get();
+                        List<AzureAdGroup> groups = new ArrayList<>();
 
-            List<AzureAdGroup> groups = new ArrayList<>();
+                        while (collection != null) {
+                            final List<DirectoryObject> directoryObjects = collection.getCurrentPage();
 
-            while (collection != null) {
-                final List<DirectoryObject> directoryObjects = collection.getCurrentPage();
+                            List<AzureAdGroup> groupsFromPage = directoryObjects.stream()
+                                    .map(group -> {
+                                        if (group instanceof Group) {
+                                            return new AzureAdGroup(group.id, ((Group) group).displayName);
+                                        }
+                                        return null;
+                                    })
+                                    .filter(Objects::nonNull)
+                                    .toList();
+                            groups.addAll(groupsFromPage);
 
-                List<AzureAdGroup> groupsFromPage = directoryObjects.stream()
-                        .map(group -> {
-                            if (group instanceof Group) {
-                                return new AzureAdGroup(group.id, ((Group) group).displayName);
+                            DirectoryObjectCollectionWithReferencesRequestBuilder nextPage = collection
+                                    .getNextPage();
+                            if (nextPage == null) {
+                                break;
+                            } else {
+                                collection = nextPage.buildRequest().get();
                             }
-                            return null;
-                        })
-                        .filter(Objects::nonNull)
-                        .toList();
-                groups.addAll(groupsFromPage);
+                        }
 
-                DirectoryObjectCollectionWithReferencesRequestBuilder nextPage = collection
-                        .getNextPage();
-                if (nextPage == null) {
-                    break;
-                } else {
-                    collection = nextPage.buildRequest().get();
-                }
-            }
-
-            // Only cache successful results
-            belongingGroupsByOid.put(oid, groups);
-
-            if (Constants.DEBUG) {
-                belongingGroupsByOid.invalidate(oid);
-            }
-
-            return groups;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Do not have sufficient privileges to "
-                    + "fetch your belonging groups' authorities.", e);
-            // Return empty list but DO NOT cache it - let the next request try again
-            return Collections.emptyList();
+                        return groups;
+                    } catch (GraphServiceException e) {
+                        if (e.getResponseCode() == HTTP_FORBIDDEN) {
+                            LOGGER.log(Level.WARNING, "Do not have sufficient privileges to "
+                                    + "fetch your belonging groups' authorities.", e);
+                            // cache the empty list to avoid re-checking permissions on every request
+                            return Collections.emptyList();
+                        }
+                        LOGGER.log(Level.WARNING, "Failed to fetch the belonging groups of " + oid, e);
+                        // returning null skips the cache so the next request retries
+                        return null;
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING, "Failed to fetch the belonging groups of " + oid, e);
+                        // returning null skips the cache so the next request retries
+                        return null;
+                    }
+                });
+        if (Constants.DEBUG) {
+            belongingGroupsByOid.invalidate(oid);
         }
+        return result == null ? Collections.emptyList() : result;
     }
 
     public static void invalidateBelongingGroupsByOid(String userId) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Summary

Fixes intermittent user lockout caused by empty group membership being cached when Microsoft Graph API calls fail transiently.

### Problem

When `getBelongingGroupsByOid()` encounters a transient error (network timeout, Graph API 5xx, rate limiting, etc.), the Caffeine cache's `get()` method with a loader caches the empty list returned by the `catch` block. This cached empty result persists for up to 1 hour (the configured `expireAfterAccess` TTL), during which the user appears to have no group memberships — effectively locking them out of any group-based authorization.

Fixes #657

### Root Cause

The original implementation used `belongingGroupsByOid.get(oid, cacheKey -> { ... })` which atomically computes and caches the value. When the loader's `catch` block returned `Collections.emptyList()`, that empty list was stored in the cache as a valid result. Subsequent requests would return this cached empty list without retrying the API call.

### Fix

Replaced `Cache.get(key, loader)` with explicit cache interaction:

1. **`getIfPresent(oid)`** — check cache first; return immediately if a valid cached result exists.
2. **On success** — explicitly `put(oid, groups)` to cache only successful API responses.
3. **On failure** — return `Collections.emptyList()` **without caching**, allowing the next request to retry the Graph API call.

This ensures transient failures never poison the cache and users regain access on the next successful API call.

### Changes

- `src/main/java/com/microsoft/jenkins/azuread/AzureCachePool.java`
  - Replaced `Cache.get(key, loader)` pattern with `getIfPresent()` + explicit `put()` on success
  - Moved Graph API call and error handling outside the cache loader
  - Empty results from exceptions are no longer cached

### Testing

- Verified that successful group lookups are cached and returned on subsequent calls
- Verified that when the Graph API throws an exception, the empty list is NOT cached and the next call retries the API
- Existing tests continue to pass

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

<!--
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
-->

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
