### PR TITLE
#827 -  Add documentation to clarify required Platform Type in Microsoft Entra ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ A Jenkins Plugin that supports authentication & authorization via Microsoft Entr
 
 1. Click `New registration`
 
-1. Add a new Reply URL `https://{your_jenkins_host}/securityRealm/finishLogin`. Make sure "Jenkins URL" (Manage Jenkins => Configure System) is set to the same value as `https://{your_jenkins_host}`.
+1. Add a new Reply URL `https://{your_jenkins_host}/securityRealm/finishLogin`. 
+
+   - Make sure "Jenkins URL" (Manage Jenkins => Configure System) is set to the same value as `https://{your_jenkins_host}`.
+
+   - Verify that the `Platform Type` is "Web" (Manage => Authentication => Redirect URI configuration => Platform Type), and ensure that the `Redirect URI` is set to `https://{your_jenkins_host}/securityRealm/finishLogin`.
 
 1. Click `Certificates & secrets`
 


### PR DESCRIPTION
Add to the documentation  when creating an application in Entra ID.

Verify that the `Platform Type` of the Redirect URI is "Web".

### Testing done

Testing login when the `Platform Type` is `Single-page application` - Fails in a loop generating the error mentioned in the issue (#827). Changing the `Platform Type` to `Web` resolves the  issue.

Tested using Jenkins Core version: 2.575-jdk21 and the plugin's version: 692.vec873983b_f50.


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
